### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/Yllibed.TenantCloudClient.Tests/Yllibed.TenantCloudClient.Tests.csproj
+++ b/src/Yllibed.TenantCloudClient.Tests/Yllibed.TenantCloudClient.Tests.csproj
@@ -8,9 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="5.10.3" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.10" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
 		<PackageReference Include="coverlet.collector" Version="1.3.0" />
 	</ItemGroup>


### PR DESCRIPTION
Hi@carldebilly, I found an issue in the Yllibed.TenantCloudClient.Tests.csproj:

Packages Microsoft.Extensions.Configuration.UserSecrets v3.1.8, Microsoft.NET.Test.Sdk v16.7.1 and MSTest.TestAdapter v2.1.2  transitively introduce 88 dependencies into TenantCloudClient’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/TenantCloudClient.html)), while Microsoft.Extensions.Configuration.UserSecrets v3.1.10, Microsoft.NET.Test.Sdk v16.9.1 and MSTest.TestAdapter v2.2.1 can only introduce 57 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/TenantCloudClient_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose