### PR TITLE
Add tc-mcp MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,108 @@ jobs:
           --api-key ${{ secrets.NUGET_API_KEY }}
           --skip-duplicate
 
+  publish-binaries:
+    name: Publish Binaries
+    needs: build-test-pack
+    if: success() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rid: [win-x64, osx-x64, osx-arm64, linux-x64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: ga
+
+      - name: Publish for ${{ matrix.rid }}
+        run: >-
+          dotnet publish
+          src/Yllibed.TenantCloudClient.Mcp/Yllibed.TenantCloudClient.Mcp.csproj
+          -c Release
+          -r ${{ matrix.rid }}
+          -o publish/${{ matrix.rid }}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tc-mcp-${{ matrix.rid }}
+          path: publish/${{ matrix.rid }}/tc-mcp*
+          retention-days: 14
+
+  release:
+    name: Create Release
+    needs: [build-test-pack, publish-binaries]
+    if: success() && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: ga
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          dotnet tool install -g nbgv
+          $v = nbgv get-version -v NuGetPackageVersion
+          echo "version=$v" >> $env:GITHUB_OUTPUT
+
+      - name: Download packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: packages
+          path: artifacts/packages
+
+      - name: Download binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: tc-mcp-*
+          path: artifacts/binaries
+          merge-multiple: false
+
+      - name: Prepare release assets
+        shell: bash
+        run: |
+          mkdir -p release-assets
+          cp artifacts/packages/*.nupkg release-assets/ 2>/dev/null || true
+          for dir in artifacts/binaries/tc-mcp-*/; do
+            rid=$(basename "$dir" | sed 's/tc-mcp-//')
+            for f in "$dir"tc-mcp*; do
+              [ -f "$f" ] || continue
+              ext="${f##*.}"
+              base="${f%.*}"
+              if [ "$ext" = "pdb" ] || [ "$ext" = "xml" ]; then
+                continue
+              fi
+              if [ "$ext" = "$f" ] || [ "$ext" = "$(basename "$f")" ]; then
+                cp "$f" "release-assets/tc-mcp-${rid}"
+              else
+                cp "$f" "release-assets/tc-mcp-${rid}.${ext}"
+              fi
+            done
+          done
+          ls -la release-assets/
+
       - name: Create GitHub Release
-        if: success() && github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/'))
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           gh release create "v${{ steps.version.outputs.version }}"
-          "${{ runner.temp }}/packages/*.nupkg"
+          release-assets/*
           --title "v${{ steps.version.outputs.version }}"
           --generate-notes
           ${{ contains(steps.version.outputs.version, '-') && '--prerelease' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,10 @@ jobs:
   publish-binaries:
     name: Publish Binaries
     needs: build-test-pack
-    if: success() && github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rid: [any, win-x64, win-arm64, osx-x64, osx-arm64, linux-x64, linux-arm64]
+        rid: ${{ github.event_name == 'push' && fromJson('["any","win-x64","win-arm64","osx-x64","osx-arm64","linux-x64","linux-arm64"]') || fromJson('["any","win-x64"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rid: [win-x64, osx-x64, osx-arm64, linux-x64]
+        rid: [win-x64, win-arm64, osx-x64, osx-arm64, linux-x64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,14 +219,19 @@ jobs:
           cp artifacts/packages/*.nupkg release-assets/ 2>/dev/null || true
           for dir in artifacts/binaries/tc-mcp-*/; do
             rid=$(basename "$dir" | sed 's/tc-mcp-//')
+            if [ "$rid" = "any" ]; then
+              # Portable build: zip all non-debug files
+              (cd "$dir" && zip -j "../../release-assets/tc-mcp-any.zip" \
+                $(ls tc-mcp* | grep -v '\.pdb$' | grep -v '\.xml$'))
+              continue
+            fi
             for f in "$dir"tc-mcp*; do
               [ -f "$f" ] || continue
               ext="${f##*.}"
-              base="${f%.*}"
               if [ "$ext" = "pdb" ] || [ "$ext" = "xml" ]; then
                 continue
               fi
-              if [ "$ext" = "$f" ] || [ "$ext" = "$(basename "$f")" ]; then
+              if [ "$ext" = "$(basename "$f")" ]; then
                 cp "$f" "release-assets/tc-mcp-${rid}"
               else
                 cp "$f" "release-assets/tc-mcp-${rid}.${ext}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rid: [win-x64, win-arm64, osx-x64, osx-arm64, linux-x64]
+        rid: [any, win-x64, win-arm64, osx-x64, osx-arm64, linux-x64, linux-arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -148,12 +148,25 @@ jobs:
           dotnet-quality: ga
 
       - name: Publish for ${{ matrix.rid }}
+        if: matrix.rid != 'any'
         run: >-
           dotnet publish
           src/Yllibed.TenantCloudClient.Mcp/Yllibed.TenantCloudClient.Mcp.csproj
           -c Release
           -r ${{ matrix.rid }}
           -o publish/${{ matrix.rid }}
+
+      - name: Publish portable
+        if: matrix.rid == 'any'
+        run: >-
+          dotnet publish
+          src/Yllibed.TenantCloudClient.Mcp/Yllibed.TenantCloudClient.Mcp.csproj
+          -c Release
+          -p:SelfContained=false
+          -p:PublishSingleFile=false
+          -p:PublishTrimmed=false
+          -p:PublishReadyToRun=false
+          -o publish/any
 
       - name: Upload binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/README.md
+++ b/README.md
@@ -1,207 +1,51 @@
 # Yllibed.TenantCloudClient
 
-Unofficial .NET client library for [TenantCloud](https://tenantcloud.com), a rental property management platform.
+Unofficial .NET toolkit for [TenantCloud](https://tenantcloud.com), a rental property management platform. Includes a client library for programmatic access and an MCP server for AI agent integration.
 
-[![Build Status](https://dev.azure.com/yllibed/TenantCloudClient/_apis/build/status/yllibed.TenantCloudClient?branchName=master)](https://dev.azure.com/yllibed/TenantCloudClient/_build/latest?definitionId=1&branchName=master) [![Nuget](https://img.shields.io/nuget/dt/Yllibed.TenantCloudClient.svg?label=nuget.org)](https://www.nuget.org/packages/Yllibed.TenantCloudClient)
+[![CI](https://github.com/yllibed/TenantCloudClient/actions/workflows/ci.yml/badge.svg)](https://github.com/yllibed/TenantCloudClient/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/dt/Yllibed.TenantCloudClient.svg?label=nuget.org)](https://www.nuget.org/packages/Yllibed.TenantCloudClient)
 
 > **This is not an official TenantCloud product.** TenantCloud does not provide a public API; this library works against their internal endpoints.
 
-## Packages
+## Packages & Binaries
 
-| Package | Description |
-|---------|-------------|
-| [`Yllibed.TenantCloudClient`](https://www.nuget.org/packages/Yllibed.TenantCloudClient/) | Core library: API client, token store abstractions, and OS-native secure storage |
-| [`Yllibed.TenantCloudClient.Cdp`](https://www.nuget.org/packages/Yllibed.TenantCloudClient.Cdp/) | Chrome DevTools Protocol token provider (extracts tokens from a running browser) |
+| Component | Type | Description |
+|-----------|------|-------------|
+| [`Yllibed.TenantCloudClient`](https://www.nuget.org/packages/Yllibed.TenantCloudClient/) | NuGet | Core library: API client, token store abstractions, OS-native secure storage |
+| [`Yllibed.TenantCloudClient.Cdp`](https://www.nuget.org/packages/Yllibed.TenantCloudClient.Cdp/) | NuGet | Chrome DevTools Protocol token provider (extracts tokens from a running browser) |
+| `tc-mcp` | Binary | MCP server for AI agents (Claude Desktop, Claude Code, Cursor, etc.) |
 
-Both packages target **net8.0** and **net10.0** with no external runtime dependencies beyond `System.Text.Json` and `Microsoft.Extensions.DependencyInjection.Abstractions`.
+## Documentation
+
+- **[Client Library](docs/client-library.md)** — Quick start, DI setup, API reference, filters, paginated sources
+- **[MCP Server](docs/mcp-server.md)** — Installation, auto-configuration for AI agents, available tools
+- **[Authentication](docs/authentication.md)** — CDP flow, SecureTokenStore, FileTokenStore, custom providers
 
 ## Quick start
 
-### With dependency injection
+### Client library (NuGet)
 
 ```csharp
 services
     .AddSecureTokenStore()      // ITcTokenStore → OS credential store
     .AddCdpTokenProvider()      // ITcAuthTokenProvider → browser extraction + auto-refresh
     .AddTenantCloudClient();    // ITcClient → TcClient
+
+// Then inject ITcClient wherever you need it
+var user = await tc.GetUserInfo(ct);
+var contacts = await tc.Contacts.OnlyTenants().GetAll(ct);
 ```
 
-Then inject `ITcClient` wherever you need it:
+### MCP server (binary)
 
-```csharp
-public class MyService(ITcClient tc)
-{
-    public async Task<TcUserInfo?> WhoAmI(CancellationToken ct)
-        => await tc.GetUserInfo(ct);
-}
+Download `tc-mcp` from [GitHub Releases](https://github.com/yllibed/TenantCloudClient/releases), then:
+
+```bash
+# Auto-configure for Claude Desktop or Claude Code
+tc-mcp install claude-desktop
+tc-mcp install claude-code
 ```
 
-### Without dependency injection
-
-```csharp
-var tokenStore = new SecureTokenStore();
-var tokenProvider = new CdpTokenProvider(new CdpTokenProviderOptions
-{
-    TokenStore = tokenStore,
-    AllowInteractiveLogin = true,
-});
-
-using var client = new TcClient(tokenProvider);
-var user = await client.GetUserInfo(ct);
-```
-
-## Authentication
-
-`TcClient` requires an `ITcAuthTokenProvider` to supply Bearer tokens. The library does not store or manage credentials directly.
-
-```csharp
-public interface ITcAuthTokenProvider
-{
-    Task<string?> GetToken(CancellationToken ct);
-    Task OnTokenRejected(CancellationToken ct, string rejectedToken);
-}
-```
-
-### Built-in: `CdpTokenProvider`
-
-Provided by the **Yllibed.TenantCloudClient.Cdp** package. Extracts auth tokens from a running Chromium browser via the Chrome DevTools Protocol, with automatic JWT refresh.
-
-```csharp
-services.AddCdpTokenProvider(options =>
-{
-    options.DebugPort = 9222;               // CDP debug port (default)
-    options.AllowInteractiveLogin = true;   // launch a browser if no session found
-});
-```
-
-The provider follows a multi-step strategy:
-1. In-memory cache (if the JWT is still valid)
-2. Token store (load + refresh if expired)
-3. CDP extraction from an existing browser tab on `app.tenantcloud.com`
-4. Interactive login (if `AllowInteractiveLogin` is enabled) — launches a browser window and waits for the user to sign in
-
-### Custom provider
-
-Implement `ITcAuthTokenProvider` and register it before calling `AddTenantCloudClient()`:
-
-```csharp
-services.AddSingleton<ITcAuthTokenProvider, MyCustomTokenProvider>();
-services.AddTenantCloudClient();
-```
-
-## Token persistence
-
-`ITcTokenStore` allows tokens to survive across process restarts. Both the core library and the CDP provider can use it.
-
-```csharp
-public interface ITcTokenStore
-{
-    Task<TcTokenSet?> LoadAsync(CancellationToken ct);
-    Task SaveAsync(TcTokenSet tokens, CancellationToken ct);
-}
-```
-
-### Built-in stores
-
-| Store | Package | Description |
-|-------|---------|-------------|
-| `SecureTokenStore` | Core | OS-native credential storage: **DPAPI** (Windows), **Keychain** (macOS), **Secret Service** (Linux) |
-| `FileTokenStore` | Cdp | Plain JSON file with atomic writes (useful for headless/CI scenarios) |
-
-```csharp
-// OS-native secure storage (recommended)
-services.AddSecureTokenStore();
-
-// With custom options
-services.AddSecureTokenStore(options =>
-{
-    options.ServiceName = "MyApp";
-    options.AccountKey = "production";
-});
-
-// Or file-based (from the Cdp package, register manually)
-services.AddSingleton<ITcTokenStore>(new FileTokenStore("/path/to/tokens.json"));
-```
-
-### Custom store
-
-Implement `ITcTokenStore` to persist tokens wherever you need (database, Azure Key Vault, etc.):
-
-```csharp
-services.AddSingleton<ITcTokenStore, MyDatabaseTokenStore>();
-```
-
-## API reference
-
-### `ITcClient`
-
-| Member | Type | Description |
-|--------|------|-------------|
-| `GetUserInfo(ct)` | `Task<TcUserInfo?>` | Current signed-in user info |
-| `Contacts` | `IPaginatedSource<TcContact>` | Contacts (tenants, professionals) |
-| `Properties` | `IPaginatedSource<TcProperty>` | Properties |
-| `Units` | `IPaginatedSource<TcUnit>` | Rental units |
-| `Transactions` | `IPaginatedSource<TcTransaction>` | Financial transactions |
-| `Leases` | `IPaginatedSource<TcLease>` | Leases |
-
-### Paginated sources
-
-Each collection is an `IPaginatedSource<T>`. Call `.GetAll(ct)` to fetch all pages, or `.GetAll(ct, maxResults: n)` to cap the fetch:
-
-```csharp
-var contacts = await client.Contacts.OnlyMovedIn().GetAll(ct);
-```
-
-The result is a `ReadOnlySequence<T>` (one segment per API page). Use `.AsEnumerable()` to bridge to LINQ:
-
-```csharp
-var names = (await client.Contacts.GetAll(ct))
-    .AsEnumerable()
-    .Select(c => c.Name)
-    .ToArray();
-```
-
-### Filters
-
-Filters are chainable extension methods that narrow the API query before fetching.
-
-**Contacts**
-- `.OnlyTenants()` — tenant contacts only
-- `.OnlyMovedIn()` — tenants with active leases
-- `.OnlyProfessionals()` — professional contacts only
-- `.OnlyArchived()` — archived contacts
-
-**Leases**
-- `.OnlyActive()` — active leases
-- `.ForProperty(propertyId)` — filter by property
-- `.ForUnit(unitId)` — filter by unit
-
-**Units**
-- `.OnlyOccuped()` — units with active leases
-- `.OnlyVacant()` — vacant units
-- `.ForProperty(propertyId)` — filter by property
-
-**Transactions**
-- `.ForTenant(tenantId)` — filter by tenant
-- `.ForProperty(propertyId)` — filter by property
-- `.ForUnit(unitId)` — filter by unit
-- `.ForStatus(TcTransactionStatus)` — filter by status (`Due`, `Paid`, `Partial`, `Pending`, `Void`, `WithBalance`, `Overdue`, `Waive`)
-- `.ForCategory(TcTransactionCategory)` — filter by category (`Income`, `Expense`, `Refund`, `Credits`, `Liability`)
-- `.SortByDateDescending()` — reverse chronological order
-
-### Example: overdue income per property
-
-```csharp
-var balancePerProperty = (await client.Transactions
-        .ForCategory(TcTransactionCategory.Income)
-        .ForStatus(TcTransactionStatus.WithBalance)
-        .GetAll(ct))
-    .AsEnumerable()
-    .Where(t => t.PropertyId != null)
-    .GroupBy(t => (long)t.PropertyId!, t => t.Balance)
-    .Select(g => new { PropertyId = g.Key, Balance = g.Sum() })
-    .ToArray();
-```
+Then ask your AI agent: *"List my TenantCloud properties"* or *"Who are my tenants?"*
 
 ## License
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,100 @@
+# Authentication
+
+TenantCloud does not offer a public OAuth or API-key flow. This library authenticates by extracting JWT tokens from a running browser session via the Chrome DevTools Protocol (CDP).
+
+## How the CDP flow works
+
+1. **Browser extraction** — connects to a Chromium browser's CDP debug port, looks for a tab on `app.tenantcloud.com`, and reads `access_token` + `fingerprint` from `localStorage` and `tc_refresh_token` from cookies
+2. **Token refresh** — when the JWT expires, the library calls TenantCloud's refresh endpoint with the refresh token and fingerprint
+3. **Persist & loop** — refreshed tokens are saved to the configured `ITcTokenStore` for next launch
+
+### Interactive login
+
+If `AllowInteractiveLogin` is enabled and no existing session is found, the provider launches a temporary Chromium instance pointing to the TenantCloud login page. Once you sign in, tokens are extracted automatically.
+
+## Token persistence — `ITcTokenStore`
+
+Tokens can survive across process restarts via `ITcTokenStore`:
+
+```csharp
+public interface ITcTokenStore
+{
+    Task<TcTokenSet?> LoadAsync(CancellationToken ct);
+    Task SaveAsync(TcTokenSet tokens, CancellationToken ct);
+}
+```
+
+### `SecureTokenStore` (recommended)
+
+Uses the OS-native credential store:
+
+| OS | Backend |
+|----|---------|
+| Windows | DPAPI (`CredWrite` / `CredRead`) |
+| macOS | Keychain (`security` CLI) |
+| Linux | Secret Service D-Bus API |
+
+```csharp
+services.AddSecureTokenStore();
+
+// With custom options
+services.AddSecureTokenStore(options =>
+{
+    options.ServiceName = "MyApp";
+    options.AccountKey = "production";
+});
+```
+
+### `FileTokenStore`
+
+Plain JSON file with atomic writes. Useful for headless/CI scenarios where no credential store is available:
+
+```csharp
+services.AddSingleton<ITcTokenStore>(new FileTokenStore("/path/to/tokens.json"));
+```
+
+> **Security note**: the file contains sensitive refresh tokens. Protect it with appropriate file permissions.
+
+### Custom store
+
+Implement `ITcTokenStore` to persist tokens wherever you need (database, Azure Key Vault, etc.):
+
+```csharp
+services.AddSingleton<ITcTokenStore, MyDatabaseTokenStore>();
+```
+
+## Token provider — `ITcAuthTokenProvider`
+
+The token provider is responsible for supplying Bearer tokens to `TcClient`:
+
+```csharp
+public interface ITcAuthTokenProvider
+{
+    Task<string?> GetToken(CancellationToken ct);
+    Task OnTokenRejected(CancellationToken ct, string rejectedToken);
+}
+```
+
+### Built-in: `CdpTokenProvider`
+
+Provided by the `Yllibed.TenantCloudClient.Cdp` package. Multi-step strategy:
+
+1. In-memory cache (if the JWT is still valid)
+2. Token store (load + refresh if expired)
+3. CDP extraction from an existing browser tab
+4. Interactive login (if `AllowInteractiveLogin` is enabled)
+
+```csharp
+services.AddCdpTokenProvider(options =>
+{
+    options.DebugPort = 9222;
+    options.AllowInteractiveLogin = true;
+});
+```
+
+### Custom provider
+
+```csharp
+services.AddSingleton<ITcAuthTokenProvider, MyCustomTokenProvider>();
+services.AddTenantCloudClient();
+```

--- a/docs/client-library.md
+++ b/docs/client-library.md
@@ -1,0 +1,112 @@
+# Client Library
+
+The `Yllibed.TenantCloudClient` and `Yllibed.TenantCloudClient.Cdp` NuGet packages provide programmatic access to TenantCloud data.
+
+Both packages target **net8.0** and **net10.0** with no external runtime dependencies beyond `System.Text.Json` and `Microsoft.Extensions.DependencyInjection.Abstractions`.
+
+## Quick start
+
+### With dependency injection
+
+```csharp
+services
+    .AddSecureTokenStore()      // ITcTokenStore → OS credential store
+    .AddCdpTokenProvider()      // ITcAuthTokenProvider → browser extraction + auto-refresh
+    .AddTenantCloudClient();    // ITcClient → TcClient
+```
+
+Then inject `ITcClient` wherever you need it:
+
+```csharp
+public class MyService(ITcClient tc)
+{
+    public async Task<TcUserInfo?> WhoAmI(CancellationToken ct)
+        => await tc.GetUserInfo(ct);
+}
+```
+
+### Without dependency injection
+
+```csharp
+var tokenStore = new SecureTokenStore();
+var tokenProvider = new CdpTokenProvider(new CdpTokenProviderOptions
+{
+    TokenStore = tokenStore,
+    AllowInteractiveLogin = true,
+});
+
+using var client = new TcClient(tokenProvider);
+var user = await client.GetUserInfo(ct);
+```
+
+## API reference
+
+### `ITcClient`
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `GetUserInfo(ct)` | `Task<TcUserInfo?>` | Current signed-in user info |
+| `Contacts` | `IPaginatedSource<TcContact>` | Contacts (tenants, professionals) |
+| `Properties` | `IPaginatedSource<TcProperty>` | Properties |
+| `Units` | `IPaginatedSource<TcUnit>` | Rental units |
+| `Transactions` | `IPaginatedSource<TcTransaction>` | Financial transactions |
+| `Leases` | `IPaginatedSource<TcLease>` | Leases |
+
+### Paginated sources
+
+Each collection is an `IPaginatedSource<T>`. Call `.GetAll(ct)` to fetch all pages, or `.GetAll(ct, maxResults: n)` to cap the fetch:
+
+```csharp
+var contacts = await client.Contacts.OnlyMovedIn().GetAll(ct);
+```
+
+The result is a `ReadOnlySequence<T>` (one segment per API page). Use `.AsEnumerable()` to bridge to LINQ:
+
+```csharp
+var names = (await client.Contacts.GetAll(ct))
+    .AsEnumerable()
+    .Select(c => c.Name)
+    .ToArray();
+```
+
+### Filters
+
+Filters are chainable extension methods that narrow the API query before fetching.
+
+**Contacts**
+- `.OnlyTenants()` — tenant contacts only
+- `.OnlyMovedIn()` — tenants with active leases
+- `.OnlyProfessionals()` — professional contacts only
+- `.OnlyArchived()` — archived contacts
+
+**Leases**
+- `.OnlyActive()` — active leases
+- `.ForProperty(propertyId)` — filter by property
+- `.ForUnit(unitId)` — filter by unit
+
+**Units**
+- `.OnlyOccuped()` — units with active leases
+- `.OnlyVacant()` — vacant units
+- `.ForProperty(propertyId)` — filter by property
+
+**Transactions**
+- `.ForTenant(tenantId)` — filter by tenant
+- `.ForProperty(propertyId)` — filter by property
+- `.ForUnit(unitId)` — filter by unit
+- `.ForStatus(TcTransactionStatus)` — filter by status (`Due`, `Paid`, `Partial`, `Pending`, `Void`, `WithBalance`, `Overdue`, `Waive`)
+- `.ForCategory(TcTransactionCategory)` — filter by category (`Income`, `Expense`, `Refund`, `Credits`, `Liability`)
+- `.SortByDateDescending()` — reverse chronological order
+
+### Example: overdue income per property
+
+```csharp
+var balancePerProperty = (await client.Transactions
+        .ForCategory(TcTransactionCategory.Income)
+        .ForStatus(TcTransactionStatus.WithBalance)
+        .GetAll(ct))
+    .AsEnumerable()
+    .Where(t => t.PropertyId != null)
+    .GroupBy(t => (long)t.PropertyId!, t => t.Balance)
+    .Select(g => new { PropertyId = g.Key, Balance = g.Sum() })
+    .ToArray();
+```

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,97 @@
+# MCP Server (`tc-mcp`)
+
+`tc-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes TenantCloud data to AI agents like Claude Desktop, Claude Code, and Cursor.
+
+## Installation
+
+Download the binary for your platform from [GitHub Releases](https://github.com/yllibed/TenantCloudClient/releases):
+
+| Platform | Binary |
+|----------|--------|
+| Windows x64 | `tc-mcp-win-x64.exe` |
+| macOS x64 | `tc-mcp-osx-x64` |
+| macOS ARM | `tc-mcp-osx-arm64` |
+| Linux x64 | `tc-mcp-linux-x64` |
+
+The binary is self-contained (no .NET runtime required).
+
+## Auto-configuration
+
+```bash
+# For Claude Desktop
+tc-mcp install claude-desktop
+
+# For Claude Code
+tc-mcp install claude-code
+```
+
+### What `install` does
+
+**Claude Desktop** — patches the config JSON at:
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+**Claude Code** — runs `claude mcp add --transport stdio tc-mcp -- <exePath>`
+
+## Manual configuration
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "tc-mcp": {
+      "command": "/path/to/tc-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add --transport stdio tc-mcp -- /path/to/tc-mcp
+```
+
+### Cursor / other MCP clients
+
+Use stdio transport with the `tc-mcp` binary path as the command.
+
+## Available tools
+
+| Tool | Description | Filters |
+|------|-------------|---------|
+| `get_user_info` | Current signed-in user profile | — |
+| `list_contacts` | Tenants, professionals, etc. | `role`, `maxResults` |
+| `list_properties` | Rental properties | `maxResults` |
+| `list_units` | Rental units | `propertyId`, `occupancy`, `maxResults` |
+| `list_transactions` | Financial transactions | `tenantId`, `propertyId`, `unitId`, `status`, `category`, `maxResults` |
+| `list_leases` | Lease agreements | `propertyId`, `unitId`, `status`, `maxResults` |
+
+## Available resources
+
+| URI | Description |
+|-----|-------------|
+| `tc://guide` | Tool usage guide — entities, fields, filters, and how to resolve names to IDs |
+
+## Authentication
+
+On first use, `tc-mcp` will attempt to authenticate via:
+
+1. **Stored token** — loaded from the OS secure credential store (DPAPI / Keychain / Secret Service)
+2. **Running browser** — extracts tokens from a Chromium browser tab open on `app.tenantcloud.com`
+3. **Interactive login** — launches a browser window for you to sign in
+
+Tokens are cached and refreshed automatically. See [Authentication](authentication.md) for details.
+
+## Example questions to ask your AI agent
+
+- "Who are my tenants?"
+- "What properties do I have?"
+- "Which units are vacant?"
+- "Show me overdue transactions"
+- "List active leases for property 12345"
+- "What is the total rent balance?"

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -18,6 +18,22 @@ Download the binary for your platform from [GitHub Releases](https://github.com/
 
 Platform-specific binaries are self-contained single-file executables (no .NET runtime required). The portable build is a zip containing `tc-mcp.dll` and its dependencies — run with `dotnet tc-mcp.dll mcp`.
 
+## Authentication
+
+Before using the MCP server, authenticate with TenantCloud:
+
+```bash
+tc-mcp login
+```
+
+This opens a browser window for you to sign in. Tokens are stored in the OS secure credential store (DPAPI on Windows, Keychain on macOS, Secret Service on Linux).
+
+To remove stored credentials:
+
+```bash
+tc-mcp logout
+```
+
 ## Auto-configuration
 
 ```bash

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -13,8 +13,10 @@ Download the binary for your platform from [GitHub Releases](https://github.com/
 | macOS x64 | `tc-mcp-osx-x64` |
 | macOS ARM64 | `tc-mcp-osx-arm64` |
 | Linux x64 | `tc-mcp-linux-x64` |
+| Linux ARM64 | `tc-mcp-linux-arm64` |
+| Portable (.NET 10) | `tc-mcp-any` |
 
-The binary is self-contained (no .NET runtime required).
+Platform-specific binaries are self-contained (no .NET runtime required). The portable build requires the .NET 10 runtime installed on the machine.
 
 ## Auto-configuration
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -9,8 +9,9 @@ Download the binary for your platform from [GitHub Releases](https://github.com/
 | Platform | Binary |
 |----------|--------|
 | Windows x64 | `tc-mcp-win-x64.exe` |
+| Windows ARM64 | `tc-mcp-win-arm64.exe` |
 | macOS x64 | `tc-mcp-osx-x64` |
-| macOS ARM | `tc-mcp-osx-arm64` |
+| macOS ARM64 | `tc-mcp-osx-arm64` |
 | Linux x64 | `tc-mcp-linux-x64` |
 
 The binary is self-contained (no .NET runtime required).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -6,17 +6,17 @@
 
 Download the binary for your platform from [GitHub Releases](https://github.com/yllibed/TenantCloudClient/releases):
 
-| Platform | Binary |
-|----------|--------|
+| Platform | Asset |
+|----------|-------|
 | Windows x64 | `tc-mcp-win-x64.exe` |
 | Windows ARM64 | `tc-mcp-win-arm64.exe` |
 | macOS x64 | `tc-mcp-osx-x64` |
 | macOS ARM64 | `tc-mcp-osx-arm64` |
 | Linux x64 | `tc-mcp-linux-x64` |
 | Linux ARM64 | `tc-mcp-linux-arm64` |
-| Portable (.NET 10) | `tc-mcp-any` |
+| Portable (.NET 10) | `tc-mcp-any.zip` |
 
-Platform-specific binaries are self-contained (no .NET runtime required). The portable build requires the .NET 10 runtime installed on the machine.
+Platform-specific binaries are self-contained single-file executables (no .NET runtime required). The portable build is a zip containing `tc-mcp.dll` and its dependencies — run with `dotnet tc-mcp.dll mcp`.
 
 ## Auto-configuration
 
@@ -34,7 +34,7 @@ tc-mcp install claude-code
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-**Claude Code** — runs `claude mcp add --transport stdio tc-mcp -- <exePath>`
+**Claude Code** — runs `claude mcp add --transport stdio tc-mcp -- <exePath> mcp`
 
 ## Manual configuration
 
@@ -47,7 +47,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "tc-mcp": {
       "command": "/path/to/tc-mcp",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -56,12 +56,12 @@ Add to your `claude_desktop_config.json`:
 ### Claude Code
 
 ```bash
-claude mcp add --transport stdio tc-mcp -- /path/to/tc-mcp
+claude mcp add --transport stdio tc-mcp -- /path/to/tc-mcp mcp
 ```
 
 ### Cursor / other MCP clients
 
-Use stdio transport with the `tc-mcp` binary path as the command.
+Use stdio transport with the `tc-mcp` binary path as the command and `mcp` as the first argument.
 
 ## Available tools
 

--- a/docs/nuget-cdp.md
+++ b/docs/nuget-cdp.md
@@ -1,0 +1,34 @@
+# Yllibed.TenantCloudClient.Cdp
+
+Chrome DevTools Protocol (CDP) based token provider for [Yllibed.TenantCloudClient](https://www.nuget.org/packages/Yllibed.TenantCloudClient/). Extracts auth tokens from an existing browser session with automatic JWT refresh.
+
+## Quick start
+
+```csharp
+services
+    .AddSecureTokenStore()      // Persist tokens in OS credential store
+    .AddCdpTokenProvider()      // Extract tokens from browser via CDP
+    .AddTenantCloudClient();    // Register ITcClient
+```
+
+## Options
+
+```csharp
+services.AddCdpTokenProvider(options =>
+{
+    options.DebugPort = 9222;               // CDP debug port (default)
+    options.AllowInteractiveLogin = true;   // Launch browser if no session found
+    options.BrowserExecutablePath = null;   // Auto-detect Chromium browser
+});
+```
+
+## How it works
+
+1. **In-memory cache** — returns the cached JWT if still valid
+2. **Token store** — loads persisted tokens and refreshes if expired
+3. **CDP extraction** — connects to a running Chromium browser and extracts tokens from a TenantCloud tab
+4. **Interactive login** — launches a temporary browser window for sign-in (if enabled)
+
+No external NuGet dependencies beyond the base client library.
+
+For full documentation, see the [GitHub repository](https://github.com/yllibed/TenantCloudClient).

--- a/docs/nuget-client.md
+++ b/docs/nuget-client.md
@@ -1,0 +1,58 @@
+# Yllibed.TenantCloudClient
+
+Unofficial .NET client library for [TenantCloud](https://tenantcloud.com), a rental property management platform.
+
+> **This is not an official TenantCloud product.** TenantCloud does not provide a public API; this library works against their internal endpoints.
+
+## Quick start
+
+### With dependency injection
+
+```csharp
+services
+    .AddSecureTokenStore()      // ITcTokenStore → OS credential store
+    .AddCdpTokenProvider()      // ITcAuthTokenProvider (from Yllibed.TenantCloudClient.Cdp)
+    .AddTenantCloudClient();    // ITcClient → TcClient
+```
+
+Then inject `ITcClient`:
+
+```csharp
+public class MyService(ITcClient tc)
+{
+    public async Task<TcUserInfo?> WhoAmI(CancellationToken ct)
+        => await tc.GetUserInfo(ct);
+}
+```
+
+### Without dependency injection
+
+```csharp
+var tokenProvider = new CdpTokenProvider(new CdpTokenProviderOptions
+{
+    TokenStore = new SecureTokenStore(),
+    AllowInteractiveLogin = true,
+});
+
+using var client = new TcClient(tokenProvider);
+var user = await client.GetUserInfo(ct);
+```
+
+## API
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `GetUserInfo(ct)` | `Task<TcUserInfo?>` | Current signed-in user |
+| `Contacts` | `IPaginatedSource<TcContact>` | Contacts (tenants, professionals) |
+| `Properties` | `IPaginatedSource<TcProperty>` | Properties |
+| `Units` | `IPaginatedSource<TcUnit>` | Rental units |
+| `Transactions` | `IPaginatedSource<TcTransaction>` | Financial transactions |
+| `Leases` | `IPaginatedSource<TcLease>` | Leases |
+
+Filters: `.OnlyTenants()`, `.OnlyActive()`, `.ForProperty(id)`, `.ForStatus(...)`, and more.
+
+```csharp
+var tenants = await client.Contacts.OnlyTenants().GetAll(ct);
+```
+
+For full documentation, see the [GitHub repository](https://github.com/yllibed/TenantCloudClient).

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,8 @@
 
 	<ItemGroup Label="Runtime dependencies">
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+		<PackageVersion Include="ModelContextProtocol" Version="0.8.0-preview.1" />
 		<PackageVersion Include="System.Text.Json" Version="9.0.4" />
 	</ItemGroup>
 

--- a/src/TenantCloud.slnx
+++ b/src/TenantCloud.slnx
@@ -1,5 +1,6 @@
 <Solution>
 	<Project Path="Yllibed.TenantCloudClient/Yllibed.TenantCloudClient.csproj" />
 	<Project Path="Yllibed.TenantCloudClient.Cdp/Yllibed.TenantCloudClient.Cdp.csproj" />
+	<Project Path="Yllibed.TenantCloudClient.Mcp/Yllibed.TenantCloudClient.Mcp.csproj" />
 	<Project Path="Yllibed.TenantCloudClient.Tests/Yllibed.TenantCloudClient.Tests.csproj" />
 </Solution>

--- a/src/Yllibed.TenantCloudClient.Cdp/FileTokenStore.cs
+++ b/src/Yllibed.TenantCloudClient.Cdp/FileTokenStore.cs
@@ -52,4 +52,14 @@ public sealed class FileTokenStore : ITcTokenStore
 			throw;
 		}
 	}
+
+	public Task DeleteAsync(CancellationToken ct)
+	{
+		if (File.Exists(_filePath))
+		{
+			File.Delete(_filePath);
+		}
+
+		return Task.CompletedTask;
+	}
 }

--- a/src/Yllibed.TenantCloudClient.Cdp/Yllibed.TenantCloudClient.Cdp.csproj
+++ b/src/Yllibed.TenantCloudClient.Cdp/Yllibed.TenantCloudClient.Cdp.csproj
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\..\docs\nuget-cdp.md" Pack="true" PackagePath="\README.md" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Yllibed.TenantCloudClient.Mcp/AuthCommands.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/AuthCommands.cs
@@ -1,0 +1,59 @@
+using Yllibed.TenantCloudClient.Cdp;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+internal static class AuthCommands
+{
+	public static async Task<int> LoginAsync()
+	{
+		if (!SecureTokenStore.IsSupported)
+		{
+			await Console.Error.WriteLineAsync("Error: Secure token storage is not supported on this platform.").ConfigureAwait(false);
+			return 1;
+		}
+
+		var store = new SecureTokenStore();
+
+		// Check if already logged in with a valid token
+		var existing = await store.LoadAsync(CancellationToken.None).ConfigureAwait(false);
+		if (existing is not null)
+		{
+			await Console.Out.WriteLineAsync("Already logged in. Use 'tc-mcp logout' first to re-authenticate.").ConfigureAwait(false);
+			return 0;
+		}
+
+		await Console.Out.WriteLineAsync("Logging in to TenantCloud...").ConfigureAwait(false);
+
+		using var provider = new CdpTokenProvider(new CdpTokenProviderOptions
+		{
+			TokenStore = store,
+			AllowInteractiveLogin = true,
+		});
+
+		var token = await provider.GetToken(CancellationToken.None).ConfigureAwait(false);
+
+		if (string.IsNullOrEmpty(token))
+		{
+			await Console.Error.WriteLineAsync("Login failed. Could not obtain a valid token.").ConfigureAwait(false);
+			return 1;
+		}
+
+		await Console.Out.WriteLineAsync("Login successful. Tokens stored in secure credential store.").ConfigureAwait(false);
+		return 0;
+	}
+
+	public static async Task<int> LogoutAsync()
+	{
+		if (!SecureTokenStore.IsSupported)
+		{
+			await Console.Error.WriteLineAsync("Error: Secure token storage is not supported on this platform.").ConfigureAwait(false);
+			return 1;
+		}
+
+		var store = new SecureTokenStore();
+		await store.DeleteAsync(CancellationToken.None).ConfigureAwait(false);
+
+		await Console.Out.WriteLineAsync("Logged out. Stored tokens have been removed.").ConfigureAwait(false);
+		return 0;
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/EntityCache.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/EntityCache.cs
@@ -73,6 +73,20 @@ internal sealed class EntityCache(ITcClient client)
 			_properties = properties.AsEnumerable().ToDictionary(p => p.Id);
 			_units = units.AsEnumerable().ToDictionary(u => u.Id);
 			_contacts = contacts.AsEnumerable().ToDictionary(c => c.Id);
+
+			// Add the signed-in user to the contacts dictionary so that
+			// user_payer_id references can be resolved to a name.
+			var userInfo = await client.GetUserInfo(ct).ConfigureAwait(false);
+			if (userInfo is not null && !_contacts.ContainsKey(userInfo.Id))
+			{
+				_contacts[userInfo.Id] = new TcContact
+				{
+					Id = userInfo.Id,
+					FirstName = userInfo.FirstName,
+					LastName = userInfo.LastName,
+					Name = $"{userInfo.FirstName} {userInfo.LastName}".Trim(),
+				};
+			}
 			_loadedAt = DateTime.UtcNow;
 		}
 		finally

--- a/src/Yllibed.TenantCloudClient.Mcp/EntityCache.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/EntityCache.cs
@@ -1,0 +1,83 @@
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+/// <summary>
+/// Caches properties, units, and contacts for fast ID-to-name resolution.
+/// </summary>
+internal sealed class EntityCache(ITcClient client)
+{
+	private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+	private readonly SemaphoreSlim _semaphore = new(1, 1);
+	private Dictionary<long, TcProperty>? _properties;
+	private Dictionary<long, TcUnit>? _units;
+	private Dictionary<long, TcContact>? _contacts;
+	private DateTime _loadedAt;
+
+	public async Task<string?> GetPropertyNameAsync(long id, CancellationToken ct)
+	{
+		await EnsureCacheAsync(ct).ConfigureAwait(false);
+		return _properties!.TryGetValue(id, out var p) ? (p.Name ?? p.Address) : null;
+	}
+
+	public async Task<string?> GetUnitNameAsync(long id, CancellationToken ct)
+	{
+		await EnsureCacheAsync(ct).ConfigureAwait(false);
+		return _units!.TryGetValue(id, out var u) ? u.Name : null;
+	}
+
+	public async Task<string?> GetContactNameAsync(long id, CancellationToken ct)
+	{
+		await EnsureCacheAsync(ct).ConfigureAwait(false);
+		return _contacts!.TryGetValue(id, out var c) ? c.Name : null;
+	}
+
+	public async Task<TcProperty?> GetPropertyAsync(long id, CancellationToken ct)
+	{
+		await EnsureCacheAsync(ct).ConfigureAwait(false);
+		return _properties!.GetValueOrDefault(id);
+	}
+
+	public async Task<TcUnit?> GetUnitAsync(long id, CancellationToken ct)
+	{
+		await EnsureCacheAsync(ct).ConfigureAwait(false);
+		return _units!.GetValueOrDefault(id);
+	}
+
+	public async Task<TcContact?> GetContactAsync(long id, CancellationToken ct)
+	{
+		await EnsureCacheAsync(ct).ConfigureAwait(false);
+		return _contacts!.GetValueOrDefault(id);
+	}
+
+	private async Task EnsureCacheAsync(CancellationToken ct)
+	{
+		if (_properties is not null && DateTime.UtcNow - _loadedAt < CacheTtl)
+		{
+			return;
+		}
+
+		await _semaphore.WaitAsync(ct).ConfigureAwait(false);
+		try
+		{
+			if (_properties is not null && DateTime.UtcNow - _loadedAt < CacheTtl)
+			{
+				return;
+			}
+
+			var properties = await client.Properties.GetAll(ct).ConfigureAwait(false);
+			var units = await client.Units.GetAll(ct).ConfigureAwait(false);
+			var contacts = await client.Contacts.GetAll(ct).ConfigureAwait(false);
+
+			_properties = properties.AsEnumerable().ToDictionary(p => p.Id);
+			_units = units.AsEnumerable().ToDictionary(u => u.Id);
+			_contacts = contacts.AsEnumerable().ToDictionary(c => c.Id);
+			_loadedAt = DateTime.UtcNow;
+		}
+		finally
+		{
+			_semaphore.Release();
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/EntityEnricher.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/EntityEnricher.cs
@@ -24,11 +24,14 @@ internal static class EntityEnricher
 
 		var propertyIds = CollectIds(dataArray, "property_id");
 		var unitIds = CollectIds(dataArray, "unit_id");
+		var contactIds = CollectIds(dataArray, "user_client_id");
+		contactIds.UnionWith(CollectIds(dataArray, "user_payer_id"));
 
 		var references = new JsonObject();
 
 		await AddReferencesAsync(references, "properties", propertyIds, cache.GetPropertyNameAsync, ct).ConfigureAwait(false);
 		await AddReferencesAsync(references, "units", unitIds, ResolveUnitWithProperty(cache), ct).ConfigureAwait(false);
+		await AddReferencesAsync(references, "contacts", contactIds, cache.GetContactNameAsync, ct).ConfigureAwait(false);
 
 		if (references.Count > 0)
 		{

--- a/src/Yllibed.TenantCloudClient.Mcp/EntityEnricher.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/EntityEnricher.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+/// <summary>
+/// Post-processes tool JSON output to append a <c>references</c> lookup table
+/// that maps foreign-key IDs to human-readable names.
+/// </summary>
+internal static class EntityEnricher
+{
+	/// <summary>
+	/// Parses the JSON, collects <c>property_id</c> and <c>unit_id</c> values from the
+	/// <c>data</c> array, resolves them via the cache, and appends a <c>references</c>
+	/// section to the root object.
+	/// </summary>
+	public static async Task<string> EnrichAsync(string json, EntityCache cache, CancellationToken ct)
+	{
+		var node = JsonNode.Parse(json);
+		if (node is not JsonObject root || root["data"] is not JsonArray dataArray)
+		{
+			return json;
+		}
+
+		var propertyIds = CollectIds(dataArray, "property_id");
+		var unitIds = CollectIds(dataArray, "unit_id");
+
+		var references = new JsonObject();
+
+		await AddReferencesAsync(references, "properties", propertyIds, cache.GetPropertyNameAsync, ct).ConfigureAwait(false);
+		await AddReferencesAsync(references, "units", unitIds, cache.GetUnitNameAsync, ct).ConfigureAwait(false);
+
+		if (references.Count > 0)
+		{
+			root["references"] = references;
+		}
+
+		return root.ToJsonString();
+	}
+
+	private static HashSet<long> CollectIds(JsonArray dataArray, string fieldName)
+	{
+		var ids = new HashSet<long>();
+		foreach (var item in dataArray)
+		{
+			if (item is JsonObject obj
+				&& obj[fieldName] is JsonValue v
+				&& v.TryGetValue<long>(out var id))
+			{
+				ids.Add(id);
+			}
+		}
+
+		return ids;
+	}
+
+	private static async Task AddReferencesAsync(
+		JsonObject references,
+		string sectionName,
+		HashSet<long> ids,
+		Func<long, CancellationToken, Task<string?>> resolver,
+		CancellationToken ct)
+	{
+		if (ids.Count == 0)
+		{
+			return;
+		}
+
+		var section = new JsonObject();
+		foreach (var id in ids)
+		{
+			var name = await resolver(id, ct).ConfigureAwait(false);
+			if (name is not null)
+			{
+				section[id.ToString(CultureInfo.InvariantCulture)] = name;
+			}
+		}
+
+		if (section.Count > 0)
+		{
+			references[sectionName] = section;
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/EntityEnricher.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/EntityEnricher.cs
@@ -28,7 +28,7 @@ internal static class EntityEnricher
 		var references = new JsonObject();
 
 		await AddReferencesAsync(references, "properties", propertyIds, cache.GetPropertyNameAsync, ct).ConfigureAwait(false);
-		await AddReferencesAsync(references, "units", unitIds, cache.GetUnitNameAsync, ct).ConfigureAwait(false);
+		await AddReferencesAsync(references, "units", unitIds, ResolveUnitWithProperty(cache), ct).ConfigureAwait(false);
 
 		if (references.Count > 0)
 		{
@@ -52,6 +52,21 @@ internal static class EntityEnricher
 		}
 
 		return ids;
+	}
+
+	private static Func<long, CancellationToken, Task<string?>> ResolveUnitWithProperty(EntityCache cache)
+	{
+		return async (id, ct) =>
+		{
+			var unit = await cache.GetUnitAsync(id, ct).ConfigureAwait(false);
+			if (unit is null)
+			{
+				return null;
+			}
+
+			var propertyName = await cache.GetPropertyNameAsync(unit.PropertyId, ct).ConfigureAwait(false);
+			return propertyName is not null ? $"{unit.Name} ({propertyName})" : unit.Name;
+		};
 	}
 
 	private static async Task AddReferencesAsync(

--- a/src/Yllibed.TenantCloudClient.Mcp/EntityResources.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/EntityResources.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Server;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+[McpServerResourceType]
+internal sealed class EntityResources
+{
+	[McpServerResource(
+		UriTemplate = "tc://property/{id}",
+		Name = "property",
+		Title = "Property details by ID",
+		MimeType = "application/json")]
+	[Description("Look up a property by its numeric ID. Returns name, address, and status.")]
+	public static async Task<string> GetProperty(
+		long id,
+		EntityCache cache,
+		CancellationToken ct)
+	{
+		var property = await cache.GetPropertyAsync(id, ct).ConfigureAwait(false);
+		if (property is null)
+		{
+			return NotFound("property", id);
+		}
+
+		var obj = new JsonObject
+		{
+			["id"] = property.Id,
+			["name"] = property.Name,
+			["address"] = property.Address,
+			["status"] = property.Status,
+		};
+
+		return obj.ToJsonString();
+	}
+
+	[McpServerResource(
+		UriTemplate = "tc://unit/{id}",
+		Name = "unit",
+		Title = "Unit details by ID",
+		MimeType = "application/json")]
+	[Description("Look up a rental unit by its numeric ID. Returns name, property, price, and occupancy.")]
+	public static async Task<string> GetUnit(
+		long id,
+		EntityCache cache,
+		CancellationToken ct)
+	{
+		var unit = await cache.GetUnitAsync(id, ct).ConfigureAwait(false);
+		if (unit is null)
+		{
+			return NotFound("unit", id);
+		}
+
+		var propertyName = await cache.GetPropertyNameAsync(unit.PropertyId, ct).ConfigureAwait(false);
+
+		var obj = new JsonObject
+		{
+			["id"] = unit.Id,
+			["name"] = unit.Name,
+			["propertyId"] = unit.PropertyId,
+			["propertyName"] = propertyName,
+			["price"] = unit.Price,
+			["isRented"] = unit.IsRented,
+		};
+
+		return obj.ToJsonString();
+	}
+
+	[McpServerResource(
+		UriTemplate = "tc://contact/{id}",
+		Name = "contact",
+		Title = "Contact details by ID",
+		MimeType = "application/json")]
+	[Description("Look up a contact by its numeric ID. Returns name, emails, and phones.")]
+	public static async Task<string> GetContact(
+		long id,
+		EntityCache cache,
+		CancellationToken ct)
+	{
+		var contact = await cache.GetContactAsync(id, ct).ConfigureAwait(false);
+		if (contact is null)
+		{
+			return NotFound("contact", id);
+		}
+
+		var obj = new JsonObject
+		{
+			["id"] = contact.Id,
+			["name"] = contact.Name,
+			["firstName"] = contact.FirstName,
+			["lastName"] = contact.LastName,
+			["emails"] = new JsonArray(contact.ValidEmails
+				.Where(e => e is not null)
+				.Select(e => (JsonNode)JsonValue.Create(e)!)
+				.ToArray()),
+			["phones"] = new JsonArray(contact.ValidPhones
+				.Select(p => (JsonNode)JsonValue.Create(p)!)
+				.ToArray()),
+		};
+
+		return obj.ToJsonString();
+	}
+
+	private static string NotFound(string entity, long id) =>
+		string.Create(CultureInfo.InvariantCulture, $"{entity} {id} not found");
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/InstallCommand.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/InstallCommand.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+internal static class InstallCommand
+{
+	public static int Run(ReadOnlySpan<string> args)
+	{
+		if (args.Length == 0)
+		{
+			Console.Error.WriteLine("Usage: tc-mcp install <target>");
+			Console.Error.WriteLine("  Targets: claude-desktop, claude-code");
+			return 1;
+		}
+
+		var target = args[0];
+
+		if (string.Equals(target, "claude-desktop", StringComparison.OrdinalIgnoreCase))
+		{
+			return InstallClaudeDesktop();
+		}
+
+		if (string.Equals(target, "claude-code", StringComparison.OrdinalIgnoreCase))
+		{
+			return InstallClaudeCode();
+		}
+
+		Console.Error.WriteLine($"Unknown install target: {target}");
+		Console.Error.WriteLine("  Supported targets: claude-desktop, claude-code");
+		return 1;
+	}
+
+	private static int InstallClaudeDesktop()
+	{
+		var exePath = Environment.ProcessPath;
+		if (string.IsNullOrEmpty(exePath))
+		{
+			Console.Error.WriteLine("Error: Could not determine the current executable path.");
+			return 1;
+		}
+
+		var configPath = GetClaudeDesktopConfigPath();
+		if (configPath is null)
+		{
+			Console.Error.WriteLine("Error: Could not determine Claude Desktop config location for this platform.");
+			return 1;
+		}
+
+		var configDir = Path.GetDirectoryName(configPath)!;
+		if (!Directory.Exists(configDir))
+		{
+			Directory.CreateDirectory(configDir);
+		}
+
+		JsonNode root;
+		if (File.Exists(configPath))
+		{
+			var json = File.ReadAllText(configPath);
+			root = JsonNode.Parse(json) ?? new JsonObject();
+		}
+		else
+		{
+			root = new JsonObject();
+		}
+
+		var servers = root["mcpServers"]?.AsObject();
+		if (servers is null)
+		{
+			servers = new JsonObject();
+			root["mcpServers"] = servers;
+		}
+
+		servers["tc-mcp"] = new JsonObject
+		{
+			["command"] = exePath,
+			["args"] = new JsonArray(),
+		};
+
+		var options = new JsonSerializerOptions { WriteIndented = true };
+		var output = root.ToJsonString(options);
+
+		// Atomic write: temp file + rename
+		var tempPath = configPath + ".tmp";
+		File.WriteAllText(tempPath, output);
+		File.Move(tempPath, configPath, overwrite: true);
+
+		Console.WriteLine($"Registered tc-mcp in {configPath}");
+		Console.WriteLine("Please restart Claude Desktop to pick up the changes.");
+		return 0;
+	}
+
+	private static string? GetClaudeDesktopConfigPath()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+			return Path.Combine(appData, "Claude", "claude_desktop_config.json");
+		}
+
+		if (OperatingSystem.IsMacOS())
+		{
+			var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			return Path.Combine(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+		}
+
+		// Linux — no standard Claude Desktop config path
+		return null;
+	}
+
+	private static int InstallClaudeCode()
+	{
+		var exePath = Environment.ProcessPath;
+		if (string.IsNullOrEmpty(exePath))
+		{
+			Console.Error.WriteLine("Error: Could not determine the current executable path.");
+			return 1;
+		}
+
+		try
+		{
+			var psi = new ProcessStartInfo
+			{
+				FileName = "claude",
+				ArgumentList = { "mcp", "add", "--transport", "stdio", "tc-mcp", "--", exePath },
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+			};
+
+			using var process = Process.Start(psi);
+			if (process is null)
+			{
+				Console.Error.WriteLine("Error: Failed to start 'claude' CLI. Is Claude Code installed?");
+				return 1;
+			}
+
+			process.WaitForExit();
+
+			var stdout = process.StandardOutput.ReadToEnd();
+			var stderr = process.StandardError.ReadToEnd();
+
+			if (!string.IsNullOrWhiteSpace(stdout))
+			{
+				Console.WriteLine(stdout);
+			}
+
+			if (!string.IsNullOrWhiteSpace(stderr))
+			{
+				Console.Error.WriteLine(stderr);
+			}
+
+			if (process.ExitCode == 0)
+			{
+				Console.WriteLine("Successfully registered tc-mcp with Claude Code.");
+			}
+			else
+			{
+				Console.Error.WriteLine($"claude mcp add exited with code {process.ExitCode}.");
+			}
+
+			return process.ExitCode;
+		}
+		catch (Exception ex)
+		{
+			Console.Error.WriteLine($"Error: {ex.Message}");
+			Console.Error.WriteLine("Make sure the 'claude' CLI is installed and available on your PATH.");
+			return 1;
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/InstallCommand.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/InstallCommand.cs
@@ -75,7 +75,7 @@ internal static class InstallCommand
 		servers["tc-mcp"] = new JsonObject
 		{
 			["command"] = exePath,
-			["args"] = new JsonArray(),
+			["args"] = new JsonArray("mcp"),
 		};
 
 		var options = new JsonSerializerOptions { WriteIndented = true };
@@ -123,7 +123,7 @@ internal static class InstallCommand
 			var psi = new ProcessStartInfo
 			{
 				FileName = "claude",
-				ArgumentList = { "mcp", "add", "--transport", "stdio", "tc-mcp", "--", exePath },
+				ArgumentList = { "mcp", "add", "--transport", "stdio", "tc-mcp", "--", exePath, "mcp" },
 				UseShellExecute = false,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,

--- a/src/Yllibed.TenantCloudClient.Mcp/ListResult.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/ListResult.cs
@@ -1,0 +1,9 @@
+namespace Yllibed.TenantCloudClient.Mcp;
+
+/// <summary>
+/// Wrapper for list results returned by MCP tools.
+/// </summary>
+public sealed record ListResult<T>(T[] Data)
+{
+	public int Count => Data.Length;
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/McpJsonContext.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/McpJsonContext.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+[JsonSourceGenerationOptions(
+	PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+	DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(TcUserInfo))]
+[JsonSerializable(typeof(ListResult<TcContact>))]
+[JsonSerializable(typeof(ListResult<TcProperty>))]
+[JsonSerializable(typeof(ListResult<TcUnit>))]
+[JsonSerializable(typeof(ListResult<TcTransaction>))]
+[JsonSerializable(typeof(ListResult<TcLease>))]
+internal partial class McpJsonContext : JsonSerializerContext
+{
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Program.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Program.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using Yllibed.TenantCloudClient;
+using Yllibed.TenantCloudClient.Cdp;
+using Yllibed.TenantCloudClient.Mcp;
+using Yllibed.TenantCloudClient.Mcp.Tools;
+
+if (args.Length > 0 && string.Equals(args[0], "install", StringComparison.OrdinalIgnoreCase))
+{
+	return InstallCommand.Run(args.AsSpan(1));
+}
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Logging.AddConsole(options =>
+{
+	// stdout is reserved for MCP JSON-RPC; route all logs to stderr
+	options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+
+builder.Services.AddSecureTokenStore();
+
+// Register CdpTokenProvider directly to set init-only properties via object initializer
+builder.Services.AddSingleton<ITcAuthTokenProvider>(sp =>
+	new CdpTokenProvider(new CdpTokenProviderOptions
+	{
+		TokenStore = sp.GetService<ITcTokenStore>(),
+		AllowInteractiveLogin = true,
+	}));
+
+builder.Services.AddTenantCloudClient();
+
+builder.Services
+	.AddMcpServer(o =>
+	{
+		o.ServerInfo = new()
+		{
+			Name = "tc-mcp",
+			Version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "dev",
+		};
+	})
+	.WithStdioServerTransport()
+	.WithTools<UserTools>()
+	.WithTools<ContactTools>()
+	.WithTools<PropertyTools>()
+	.WithTools<UnitTools>()
+	.WithTools<TransactionTools>()
+	.WithTools<LeaseTools>();
+
+await builder.Build().RunAsync().ConfigureAwait(false);
+
+return 0;

--- a/src/Yllibed.TenantCloudClient.Mcp/Program.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Program.cs
@@ -19,6 +19,16 @@ if (string.Equals(command, "mcp", StringComparison.OrdinalIgnoreCase))
 	return await RunMcpServer(args[1..]).ConfigureAwait(false);
 }
 
+if (string.Equals(command, "login", StringComparison.OrdinalIgnoreCase))
+{
+	return await AuthCommands.LoginAsync().ConfigureAwait(false);
+}
+
+if (string.Equals(command, "logout", StringComparison.OrdinalIgnoreCase))
+{
+	return await AuthCommands.LogoutAsync().ConfigureAwait(false);
+}
+
 // No command or unknown command — show help
 PrintHelp();
 return command is null ? 0 : 1;
@@ -32,6 +42,8 @@ static void PrintHelp()
 	Console.WriteLine();
 	Console.WriteLine("Commands:");
 	Console.WriteLine("  mcp                       Start the MCP server (stdio transport)");
+	Console.WriteLine("  login                     Authenticate and store tokens");
+	Console.WriteLine("  logout                    Remove stored tokens");
 	Console.WriteLine("  install claude-desktop     Register in Claude Desktop config");
 	Console.WriteLine("  install claude-code        Register in Claude Code via CLI");
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/Program.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Program.cs
@@ -69,6 +69,7 @@ static async Task<int> RunMcpServer(string[] args)
 		}));
 
 	builder.Services.AddTenantCloudClient();
+	builder.Services.AddSingleton<EntityCache>();
 
 	builder.Services
 		.AddMcpServer(o =>
@@ -85,7 +86,8 @@ static async Task<int> RunMcpServer(string[] args)
 		.WithTools<PropertyTools>()
 		.WithTools<UnitTools>()
 		.WithTools<TransactionTools>()
-		.WithTools<LeaseTools>();
+		.WithTools<LeaseTools>()
+		.WithResources<EntityResources>();
 
 	await builder.Build().RunAsync().ConfigureAwait(false);
 

--- a/src/Yllibed.TenantCloudClient.Mcp/Program.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Program.cs
@@ -87,6 +87,7 @@ static async Task<int> RunMcpServer(string[] args)
 		.WithTools<UnitTools>()
 		.WithTools<TransactionTools>()
 		.WithTools<LeaseTools>()
+		.WithResources<SchemaResource>()
 		.WithResources<EntityResources>();
 
 	await builder.Build().RunAsync().ConfigureAwait(false);

--- a/src/Yllibed.TenantCloudClient.Mcp/Program.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Program.cs
@@ -7,48 +7,75 @@ using Yllibed.TenantCloudClient.Cdp;
 using Yllibed.TenantCloudClient.Mcp;
 using Yllibed.TenantCloudClient.Mcp.Tools;
 
-if (args.Length > 0 && string.Equals(args[0], "install", StringComparison.OrdinalIgnoreCase))
+var command = args.Length > 0 ? args[0] : null;
+
+if (string.Equals(command, "install", StringComparison.OrdinalIgnoreCase))
 {
 	return InstallCommand.Run(args.AsSpan(1));
 }
 
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.Logging.AddConsole(options =>
+if (string.Equals(command, "mcp", StringComparison.OrdinalIgnoreCase))
 {
-	// stdout is reserved for MCP JSON-RPC; route all logs to stderr
-	options.LogToStandardErrorThreshold = LogLevel.Trace;
-});
+	return await RunMcpServer(args[1..]).ConfigureAwait(false);
+}
 
-builder.Services.AddSecureTokenStore();
+// No command or unknown command — show help
+PrintHelp();
+return command is null ? 0 : 1;
 
-// Register CdpTokenProvider directly to set init-only properties via object initializer
-builder.Services.AddSingleton<ITcAuthTokenProvider>(sp =>
-	new CdpTokenProvider(new CdpTokenProviderOptions
+static void PrintHelp()
+{
+	var version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "dev";
+	Console.WriteLine($"tc-mcp v{version} — TenantCloud MCP server");
+	Console.WriteLine();
+	Console.WriteLine("Usage: tc-mcp <command>");
+	Console.WriteLine();
+	Console.WriteLine("Commands:");
+	Console.WriteLine("  mcp                       Start the MCP server (stdio transport)");
+	Console.WriteLine("  install claude-desktop     Register in Claude Desktop config");
+	Console.WriteLine("  install claude-code        Register in Claude Code via CLI");
+}
+
+static async Task<int> RunMcpServer(string[] args)
+{
+	var builder = Host.CreateApplicationBuilder(args);
+
+	builder.Logging.AddConsole(options =>
 	{
-		TokenStore = sp.GetService<ITcTokenStore>(),
-		AllowInteractiveLogin = true,
-	}));
+		// stdout is reserved for MCP JSON-RPC; route all logs to stderr
+		options.LogToStandardErrorThreshold = LogLevel.Trace;
+	});
 
-builder.Services.AddTenantCloudClient();
+	builder.Services.AddSecureTokenStore();
 
-builder.Services
-	.AddMcpServer(o =>
-	{
-		o.ServerInfo = new()
+	// Register CdpTokenProvider directly to set init-only properties via object initializer
+	builder.Services.AddSingleton<ITcAuthTokenProvider>(sp =>
+		new CdpTokenProvider(new CdpTokenProviderOptions
 		{
-			Name = "tc-mcp",
-			Version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "dev",
-		};
-	})
-	.WithStdioServerTransport()
-	.WithTools<UserTools>()
-	.WithTools<ContactTools>()
-	.WithTools<PropertyTools>()
-	.WithTools<UnitTools>()
-	.WithTools<TransactionTools>()
-	.WithTools<LeaseTools>();
+			TokenStore = sp.GetService<ITcTokenStore>(),
+			AllowInteractiveLogin = true,
+		}));
 
-await builder.Build().RunAsync().ConfigureAwait(false);
+	builder.Services.AddTenantCloudClient();
 
-return 0;
+	builder.Services
+		.AddMcpServer(o =>
+		{
+			o.ServerInfo = new()
+			{
+				Name = "tc-mcp",
+				Version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "dev",
+			};
+		})
+		.WithStdioServerTransport()
+		.WithTools<UserTools>()
+		.WithTools<ContactTools>()
+		.WithTools<PropertyTools>()
+		.WithTools<UnitTools>()
+		.WithTools<TransactionTools>()
+		.WithTools<LeaseTools>();
+
+	await builder.Build().RunAsync().ConfigureAwait(false);
+
+	return 0;
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
@@ -110,9 +110,20 @@ internal sealed class SchemaResource
 		- `tenantId` (long?) — Tenant contact ID (see `references.contacts`)
 		- `startDate` (DateTime) — Start date
 		- `endDate` (DateTime?) — End date (null = month-to-month)
+		- `moveOutDate` (DateTime?) — Actual move-out date (null if still active)
 		- `status` (TcLeaseStatus) — Active, Archived, Ended, Expired, Future, Pending, etc.
 
-		## Tool Filters
+		## Tool Filters — CRITICAL
+
+		You MUST use server-side filters whenever the user's question targets a specific
+		property, unit, tenant, or status. **NEVER fetch all data and filter client-side**
+		when a filter parameter exists for the criterion. Server-side filtering is faster,
+		returns less data, and avoids hitting pagination limits.
+
+		For example, if the user asks about a specific unit:
+		1. Resolve the unit ID (see ID Resolution below)
+		2. Pass `unitId` to `list_leases` and `list_transactions` — do NOT call these
+		   tools without filters and then search through the results yourself.
 
 		### list_contacts
 		- `role` (string?) — Filter by role: `tenant`, `professional`, `moved_in`, `archived`
@@ -170,12 +181,19 @@ internal sealed class SchemaResource
 		When the match is ambiguous, present the candidates and ask the user to clarify.
 
 		## Typical Questions
-		- "Who are my tenants?" → list_contacts with role=tenant
-		- "What properties do I have?" → list_properties
-		- "Which units are vacant?" → list_units with occupancy=vacant
-		- "What is the rent balance for property X?" → resolve property name → list_transactions with propertyId + status=with_balance
-		- "Show me active leases for [address]" → resolve property → list_leases with propertyId + status=active
-		- "Show transactions for [tenant name]" → resolve contact → list_transactions with tenantId
-		- "Who am I logged in as?" → get_user_info
+
+		Always resolve names to IDs first, then use the appropriate filters.
+
+		- "Who are my tenants?" → `list_contacts` with `role=tenant`
+		- "What properties do I have?" → `list_properties`
+		- "Which units are vacant?" → `list_units` with `occupancy=vacant`
+		- "Which units are vacant at [property]?" → resolve property → `list_units` with `propertyId` + `occupancy=vacant`
+		- "What is the rent balance for property X?" → resolve property → `list_transactions` with `propertyId` + `status=with_balance`
+		- "Show me active leases for [address]" → resolve property → `list_leases` with `propertyId` + `status=active`
+		- "Show transactions for [tenant name]" → resolve contact → `list_transactions` with `tenantId`
+		- "Show overdue rent for unit 3B at [property]" → resolve property → resolve unit → `list_transactions` with `unitId` + `status=overdue` + `category=income`
+		- "What leases are on unit [name]?" → resolve unit → `list_leases` with `unitId`
+		- "Show all expenses for [property]" → resolve property → `list_transactions` with `propertyId` + `category=expense`
+		- "Who am I logged in as?" → `get_user_info`
 		""";
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
@@ -1,0 +1,150 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+[McpServerResourceType]
+internal sealed class SchemaResource
+{
+	[McpServerResource(
+		UriTemplate = "tc://guide",
+		Name = "guide",
+		Title = "TenantCloud Tool Usage Guide",
+		MimeType = "text/markdown")]
+	[Description("Guide for using TenantCloud tools: entities, fields, filters, and how to resolve names to IDs.")]
+	public static string GetSchema() => Schema;
+
+	private const string Schema = """
+		# TenantCloud Tool Usage Guide
+
+		## Entities
+
+		### UserInfo
+		Current signed-in user profile.
+		- `id` (long) — User ID
+		- `email` (string) — Email address
+		- `firstName`, `lastName` (string) — Name
+		- `company` (string) — Company name
+		- `phone` (string) — Phone number
+		- `address1`, `address2`, `city`, `state`, `zip` (string) — Address
+
+		### Contact
+		A tenant, professional, or other contact.
+		- `id` (long) — Contact ID
+		- `name`, `firstName`, `lastName` (string) — Name
+		- `email1`, `email2`, `email3` (string) — Up to 3 email addresses
+		- `phone1`, `phone2`, `phone3` (string) — Up to 3 phone numbers
+		- `status` (TcTenantStatus) — Contact status
+
+		### Property
+		A rental property.
+		- `id` (long) — Property ID
+		- `name` (string) — Property name
+		- `address1` (string) — Street address
+		- `cityAddress` (string) — City and state
+		- `status` (string) — Property status
+
+		### Unit
+		A rental unit within a property.
+		- `id` (long) — Unit ID
+		- `propertyId` (long) — Parent property ID
+		- `name` (string) — Unit name
+		- `description` (string?) — Description
+		- `price` (decimal) — Rent price
+		- `isRented` (bool) — Currently occupied
+		- `isPetAllowed` (bool) — Pets allowed
+		- `isFurnished` (bool) — Furnished
+		- `isUtilities` (bool) — Utilities included
+
+		### Transaction
+		A financial transaction (rent, expense, etc.).
+		- `id` (long) — Transaction ID
+		- `unitId` (long?) — Associated unit
+		- `propertyId` (long?) — Associated property
+		- `detail` (string?) — Description
+		- `amount` (decimal) — Total amount
+		- `paid` (decimal) — Amount paid
+		- `balance` (decimal) — Remaining balance
+		- `currency` (string) — Currency code
+		- `dueDate` (DateTimeOffset) — Due date
+		- `paidAt` (DateTimeOffset?) — Payment date
+		- `category` (TcTransactionCategory) — Income, Expense, Refund, Credits, Liability
+		- `status` (TcTransactionStatus) — Due, Paid, Partial, Pending, Void, WithBalance, Overdue, Waive
+		- `isRecurring` (bool) — Recurring transaction
+
+		### Lease
+		A lease agreement.
+		- `id` (long) — Lease ID
+		- `name` (string?) — Lease name
+		- `unitId` (long) — Associated unit
+		- `startDate` (DateTime) — Start date
+		- `endDate` (DateTime?) — End date (null = month-to-month)
+		- `status` (TcLeaseStatus) — Active, Archived, Ended, Expired, Future, Pending, etc.
+
+		## Tool Filters
+
+		### list_contacts
+		- `role` (string?) — Filter by role: `tenant`, `professional`, `moved_in`, `archived`
+		- `maxResults` (int?) — Max results to return (default 100)
+
+		### list_properties
+		- `maxResults` (int?) — Max results to return (default 100)
+
+		### list_units
+		- `propertyId` (long?) — Filter by property ID
+		- `occupancy` (string?) — Filter by occupancy: `occupied`, `vacant`
+		- `maxResults` (int?) — Max results to return (default 100)
+
+		### list_transactions
+		- `tenantId` (long?) — Filter by tenant/contact ID
+		- `propertyId` (long?) — Filter by property ID
+		- `unitId` (long?) — Filter by unit ID
+		- `status` (string?) — Filter by status: `due`, `paid`, `partial`, `pending`, `void`, `with_balance`, `overdue`, `waive`
+		- `category` (string?) — Filter by category: `income`, `expense`, `refund`, `credits`, `liability`
+		- `maxResults` (int?) — Max results to return (default 100)
+
+		### list_leases
+		- `propertyId` (long?) — Filter by property ID
+		- `unitId` (long?) — Filter by unit ID
+		- `status` (string?) — Filter by status: `active`
+		- `maxResults` (int?) — Max results to return (default 100)
+
+		## ID Resolution — IMPORTANT
+
+		Users refer to entities by **name**, not by ID. All filter parameters that accept an ID
+		(propertyId, unitId, tenantId) require a numeric ID. You must resolve names to IDs first.
+
+		### Resolution patterns
+
+		**Property by name/address** → call `list_properties`, then match by `name` or `address1` fields.
+		**Unit by name** → call `list_units` (optionally filtered by propertyId), then match by `name`.
+		**Tenant by name** → call `list_contacts` with role=tenant, then match by `name`, `firstName`, or `lastName`.
+
+		### Multi-step example
+
+		User asks: "List active leases for my property on Evergreen Terrace"
+		1. Call `list_properties` → find the property where `address1` or `name` contains "Evergreen Terrace" → get its `id`
+		2. Call `list_leases` with `propertyId=<resolved id>` and `status=active`
+
+		User asks: "Show transactions for John Smith"
+		1. Call `list_contacts` with `role=tenant` → find contact where `name` contains "John Smith" → get its `id`
+		2. Call `list_transactions` with `tenantId=<resolved id>`
+
+		User asks: "Which tenants are in unit 3B at Maple Heights?"
+		1. Call `list_properties` → find "Maple Heights" → get its `id`
+		2. Call `list_units` with `propertyId=<property id>` → find "3B" → get its `id`
+		3. Call `list_leases` with `unitId=<unit id>` and `status=active` → get tenant info from lease names
+
+		Always resolve in order: property → unit → tenant/lease/transaction.
+		When the match is ambiguous, present the candidates and ask the user to clarify.
+
+		## Typical Questions
+		- "Who are my tenants?" → list_contacts with role=tenant
+		- "What properties do I have?" → list_properties
+		- "Which units are vacant?" → list_units with occupancy=vacant
+		- "What is the rent balance for property X?" → resolve property name → list_transactions with propertyId + status=with_balance
+		- "Show me active leases for [address]" → resolve property → list_leases with propertyId + status=active
+		- "Show transactions for [tenant name]" → resolve contact → list_transactions with tenantId
+		- "Who am I logged in as?" → get_user_info
+		""";
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
@@ -17,6 +17,33 @@ internal sealed class SchemaResource
 	private const string Schema = """
 		# TenantCloud Tool Usage Guide
 
+		## Output Presentation — CRITICAL
+
+		You MUST present **human-readable names** to the user, never raw numeric IDs.
+
+		Tool responses that contain foreign-key IDs (`property_id`, `unit_id`) automatically
+		include a `references` section at the end of the JSON with resolved names:
+
+		```json
+		{
+		  "data": [ ... ],
+		  "count": 5,
+		  "references": {
+		    "properties": { "6587": "742 Evergreen Terrace" },
+		    "units": { "11899": "Chambre 3" }
+		  }
+		}
+		```
+
+		Use the `references` table to replace IDs with names when presenting results to the user.
+		For detailed entity information, read the MCP resources:
+		- `tc://property/{id}` — full property details
+		- `tc://unit/{id}` — full unit details (includes parent property name)
+		- `tc://contact/{id}` — full contact details
+
+		When a reference is missing (entity not found in cache), resolve it by calling
+		the corresponding list tool (`list_properties`, `list_units`, `list_contacts`).
+
 		## Entities
 
 		### UserInfo

--- a/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/SchemaResource.cs
@@ -21,8 +21,9 @@ internal sealed class SchemaResource
 
 		You MUST present **human-readable names** to the user, never raw numeric IDs.
 
-		Tool responses that contain foreign-key IDs (`property_id`, `unit_id`) automatically
-		include a `references` section at the end of the JSON with resolved names:
+		Tool responses that contain foreign-key IDs (`property_id`, `unit_id`, `user_client_id`,
+		`user_payer_id`) automatically include a `references` section at the end of the JSON with
+		resolved names:
 
 		```json
 		{
@@ -30,7 +31,8 @@ internal sealed class SchemaResource
 		  "count": 5,
 		  "references": {
 		    "properties": { "6587": "742 Evergreen Terrace" },
-		    "units": { "11899": "Chambre 3" }
+		    "units": { "11899": "Chambre 3 (742 Evergreen Terrace)" },
+		    "contacts": { "3099201": "John Smith" }
 		  }
 		}
 		```
@@ -88,6 +90,7 @@ internal sealed class SchemaResource
 		- `id` (long) — Transaction ID
 		- `unitId` (long?) — Associated unit
 		- `propertyId` (long?) — Associated property
+		- `payerId` (long?) — Payer contact ID (see `references.contacts`)
 		- `detail` (string?) — Description
 		- `amount` (decimal) — Total amount
 		- `paid` (decimal) — Amount paid
@@ -104,6 +107,7 @@ internal sealed class SchemaResource
 		- `id` (long) — Lease ID
 		- `name` (string?) — Lease name
 		- `unitId` (long) — Associated unit
+		- `tenantId` (long?) — Tenant contact ID (see `references.contacts`)
 		- `startDate` (DateTime) — Start date
 		- `endDate` (DateTime?) — End date (null = month-to-month)
 		- `status` (TcLeaseStatus) — Active, Archived, Ended, Expired, Future, Pending, etc.

--- a/src/Yllibed.TenantCloudClient.Mcp/ToolResults.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/ToolResults.cs
@@ -1,0 +1,12 @@
+using ModelContextProtocol.Protocol;
+
+namespace Yllibed.TenantCloudClient.Mcp;
+
+internal static class ToolResults
+{
+	public static CallToolResult Success(string text) =>
+		new() { Content = [new TextContentBlock { Text = text }] };
+
+	public static CallToolResult Error(string message) =>
+		new() { Content = [new TextContentBlock { Text = message }], IsError = true };
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/ContactTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/ContactTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Yllibed.TenantCloudClient.HttpMessages;
 
@@ -9,9 +10,9 @@ namespace Yllibed.TenantCloudClient.Mcp.Tools;
 internal sealed class ContactTools
 {
 	[McpServerTool(Name = "list_contacts"), Description("List contacts (tenants, professionals) from TenantCloud. Use 'role' to filter by type.")]
-	public static async Task<string> ListContacts(
+	public static async Task<CallToolResult> ListContacts(
 		ITcClient client,
-		[Description("Filter by role: tenant, professional, moved_in, archived")] string? role,
+		[Description("Filter by role: tenant, professional, moved_in, archived")] string role,
 		[Description("Maximum number of results to return (default 100)")] int? maxResults,
 		CancellationToken ct)
 	{
@@ -31,11 +32,11 @@ internal sealed class ContactTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcContact>(data.AsEnumerable().ToArray());
-			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcContact);
+			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcContact));
 		}
 		catch (TcClientException ex)
 		{
-			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+			return ToolResults.Error($"{ex.Message} (HTTP {(int)ex.HttpStatus})");
 		}
 	}
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/ContactTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/ContactTools.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp.Tools;
+
+[McpServerToolType]
+internal sealed class ContactTools
+{
+	[McpServerTool(Name = "list_contacts"), Description("List contacts (tenants, professionals) from TenantCloud. Use 'role' to filter by type.")]
+	public static async Task<string> ListContacts(
+		ITcClient client,
+		[Description("Filter by role: tenant, professional, moved_in, archived")] string? role,
+		[Description("Maximum number of results to return (default 100)")] int? maxResults,
+		CancellationToken ct)
+	{
+		try
+		{
+			var source = client.Contacts;
+
+			source = role?.ToLowerInvariant() switch
+			{
+				"tenant" => source.OnlyTenants(),
+				"professional" => source.OnlyProfessionals(),
+				"moved_in" => source.OnlyMovedIn(),
+				"archived" => source.OnlyArchived(),
+				null => source,
+				_ => source,
+			};
+
+			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
+			var result = new ListResult<TcContact>(data.AsEnumerable().ToArray());
+			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcContact);
+		}
+		catch (TcClientException ex)
+		{
+			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/LeaseTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/LeaseTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Yllibed.TenantCloudClient.HttpMessages;
 
@@ -9,7 +10,7 @@ namespace Yllibed.TenantCloudClient.Mcp.Tools;
 internal sealed class LeaseTools
 {
 	[McpServerTool(Name = "list_leases"), Description("List leases from TenantCloud. Can filter by property, unit, or status.")]
-	public static async Task<string> ListLeases(
+	public static async Task<CallToolResult> ListLeases(
 		ITcClient client,
 		[Description("Filter by property ID")] long? propertyId,
 		[Description("Filter by unit ID")] long? unitId,
@@ -38,11 +39,11 @@ internal sealed class LeaseTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcLease>(data.AsEnumerable().ToArray());
-			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcLease);
+			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcLease));
 		}
 		catch (TcClientException ex)
 		{
-			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+			return ToolResults.Error($"{ex.Message} (HTTP {(int)ex.HttpStatus})");
 		}
 	}
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/LeaseTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/LeaseTools.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp.Tools;
+
+[McpServerToolType]
+internal sealed class LeaseTools
+{
+	[McpServerTool(Name = "list_leases"), Description("List leases from TenantCloud. Can filter by property, unit, or status.")]
+	public static async Task<string> ListLeases(
+		ITcClient client,
+		[Description("Filter by property ID")] long? propertyId,
+		[Description("Filter by unit ID")] long? unitId,
+		[Description("Filter by status: active")] string? status,
+		[Description("Maximum number of results to return (default 100)")] int? maxResults,
+		CancellationToken ct)
+	{
+		try
+		{
+			var source = client.Leases;
+
+			if (propertyId.HasValue)
+			{
+				source = source.ForProperty(propertyId.Value);
+			}
+
+			if (unitId.HasValue)
+			{
+				source = source.ForUnit(unitId.Value);
+			}
+
+			if (string.Equals(status, "active", StringComparison.OrdinalIgnoreCase))
+			{
+				source = source.OnlyActive();
+			}
+
+			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
+			var result = new ListResult<TcLease>(data.AsEnumerable().ToArray());
+			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcLease);
+		}
+		catch (TcClientException ex)
+		{
+			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/LeaseTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/LeaseTools.cs
@@ -12,6 +12,7 @@ internal sealed class LeaseTools
 	[McpServerTool(Name = "list_leases"), Description("List leases from TenantCloud. Can filter by property, unit, or status.")]
 	public static async Task<CallToolResult> ListLeases(
 		ITcClient client,
+		EntityCache cache,
 		[Description("Filter by property ID")] long? propertyId,
 		[Description("Filter by unit ID")] long? unitId,
 		[Description("Filter by status: active")] string? status,
@@ -39,7 +40,9 @@ internal sealed class LeaseTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcLease>(data.AsEnumerable().ToArray());
-			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcLease));
+			var json = JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcLease);
+			json = await EntityEnricher.EnrichAsync(json, cache, ct).ConfigureAwait(false);
+			return ToolResults.Success(json);
 		}
 		catch (TcClientException ex)
 		{

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/PropertyTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/PropertyTools.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp.Tools;
+
+[McpServerToolType]
+internal sealed class PropertyTools
+{
+	[McpServerTool(Name = "list_properties"), Description("List rental properties from TenantCloud.")]
+	public static async Task<string> ListProperties(
+		ITcClient client,
+		[Description("Maximum number of results to return (default 100)")] int? maxResults,
+		CancellationToken ct)
+	{
+		try
+		{
+			var data = await client.Properties.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
+			var result = new ListResult<TcProperty>(data.AsEnumerable().ToArray());
+			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcProperty);
+		}
+		catch (TcClientException ex)
+		{
+			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/PropertyTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/PropertyTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Yllibed.TenantCloudClient.HttpMessages;
 
@@ -9,7 +10,7 @@ namespace Yllibed.TenantCloudClient.Mcp.Tools;
 internal sealed class PropertyTools
 {
 	[McpServerTool(Name = "list_properties"), Description("List rental properties from TenantCloud.")]
-	public static async Task<string> ListProperties(
+	public static async Task<CallToolResult> ListProperties(
 		ITcClient client,
 		[Description("Maximum number of results to return (default 100)")] int? maxResults,
 		CancellationToken ct)
@@ -18,11 +19,11 @@ internal sealed class PropertyTools
 		{
 			var data = await client.Properties.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcProperty>(data.AsEnumerable().ToArray());
-			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcProperty);
+			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcProperty));
 		}
 		catch (TcClientException ex)
 		{
-			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+			return ToolResults.Error($"{ex.Message} (HTTP {(int)ex.HttpStatus})");
 		}
 	}
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/TransactionTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/TransactionTools.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp.Tools;
+
+[McpServerToolType]
+internal sealed class TransactionTools
+{
+	[McpServerTool(Name = "list_transactions"), Description("List financial transactions from TenantCloud. Can filter by tenant, property, unit, status, or category.")]
+	public static async Task<string> ListTransactions(
+		ITcClient client,
+		[Description("Filter by tenant/contact ID")] long? tenantId,
+		[Description("Filter by property ID")] long? propertyId,
+		[Description("Filter by unit ID")] long? unitId,
+		[Description("Filter by status: due, paid, partial, pending, void, with_balance, overdue, waive")] string? status,
+		[Description("Filter by category: income, expense, refund, credits, liability")] string? category,
+		[Description("Maximum number of results to return (default 100)")] int? maxResults,
+		CancellationToken ct)
+	{
+		try
+		{
+			var source = client.Transactions;
+
+			if (tenantId.HasValue)
+			{
+				source = source.ForTenant(tenantId.Value);
+			}
+
+			if (propertyId.HasValue)
+			{
+				source = source.ForProperty(propertyId.Value);
+			}
+
+			if (unitId.HasValue)
+			{
+				source = source.ForUnit(unitId.Value);
+			}
+
+			if (status is not null && TryParseTransactionStatus(status, out var parsedStatus))
+			{
+				source = source.ForStatus(parsedStatus);
+			}
+
+			if (category is not null && TryParseTransactionCategory(category, out var parsedCategory))
+			{
+				source = source.ForCategory(parsedCategory);
+			}
+
+			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
+			var result = new ListResult<TcTransaction>(data.AsEnumerable().ToArray());
+			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcTransaction);
+		}
+		catch (TcClientException ex)
+		{
+			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+		}
+	}
+
+	private static bool TryParseTransactionStatus(string value, out TcTransactionStatus result)
+	{
+		result = value.ToLowerInvariant() switch
+		{
+			"due" => TcTransactionStatus.Due,
+			"paid" => TcTransactionStatus.Paid,
+			"partial" => TcTransactionStatus.Partial,
+			"pending" => TcTransactionStatus.Pending,
+			"void" => TcTransactionStatus.Void,
+			"with_balance" => TcTransactionStatus.WithBalance,
+			"overdue" => TcTransactionStatus.Overdue,
+			"waive" => TcTransactionStatus.Waive,
+			_ => default,
+		};
+
+		return value.ToLowerInvariant() is "due" or "paid" or "partial" or "pending" or "void"
+			or "with_balance" or "overdue" or "waive";
+	}
+
+	private static bool TryParseTransactionCategory(string value, out TcTransactionCategory result)
+	{
+		result = value.ToLowerInvariant() switch
+		{
+			"income" => TcTransactionCategory.Income,
+			"expense" => TcTransactionCategory.Expense,
+			"refund" => TcTransactionCategory.Refund,
+			"credits" => TcTransactionCategory.Credits,
+			"liability" => TcTransactionCategory.Liability,
+			_ => default,
+		};
+
+		return value.ToLowerInvariant() is "income" or "expense" or "refund" or "credits" or "liability";
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/TransactionTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/TransactionTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Yllibed.TenantCloudClient.HttpMessages;
 
@@ -9,7 +10,7 @@ namespace Yllibed.TenantCloudClient.Mcp.Tools;
 internal sealed class TransactionTools
 {
 	[McpServerTool(Name = "list_transactions"), Description("List financial transactions from TenantCloud. Can filter by tenant, property, unit, status, or category.")]
-	public static async Task<string> ListTransactions(
+	public static async Task<CallToolResult> ListTransactions(
 		ITcClient client,
 		[Description("Filter by tenant/contact ID")] long? tenantId,
 		[Description("Filter by property ID")] long? propertyId,
@@ -50,11 +51,11 @@ internal sealed class TransactionTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcTransaction>(data.AsEnumerable().ToArray());
-			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcTransaction);
+			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcTransaction));
 		}
 		catch (TcClientException ex)
 		{
-			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+			return ToolResults.Error($"{ex.Message} (HTTP {(int)ex.HttpStatus})");
 		}
 	}
 

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/TransactionTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/TransactionTools.cs
@@ -12,6 +12,7 @@ internal sealed class TransactionTools
 	[McpServerTool(Name = "list_transactions"), Description("List financial transactions from TenantCloud. Can filter by tenant, property, unit, status, or category.")]
 	public static async Task<CallToolResult> ListTransactions(
 		ITcClient client,
+		EntityCache cache,
 		[Description("Filter by tenant/contact ID")] long? tenantId,
 		[Description("Filter by property ID")] long? propertyId,
 		[Description("Filter by unit ID")] long? unitId,
@@ -51,7 +52,9 @@ internal sealed class TransactionTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcTransaction>(data.AsEnumerable().ToArray());
-			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcTransaction));
+			var json = JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcTransaction);
+			json = await EntityEnricher.EnrichAsync(json, cache, ct).ConfigureAwait(false);
+			return ToolResults.Success(json);
 		}
 		catch (TcClientException ex)
 		{

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/UnitTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/UnitTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Yllibed.TenantCloudClient.HttpMessages;
 
@@ -9,7 +10,7 @@ namespace Yllibed.TenantCloudClient.Mcp.Tools;
 internal sealed class UnitTools
 {
 	[McpServerTool(Name = "list_units"), Description("List rental units from TenantCloud. Can filter by property or occupancy status.")]
-	public static async Task<string> ListUnits(
+	public static async Task<CallToolResult> ListUnits(
 		ITcClient client,
 		[Description("Filter by property ID")] long? propertyId,
 		[Description("Filter by occupancy: occupied, vacant")] string? occupancy,
@@ -35,11 +36,11 @@ internal sealed class UnitTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcUnit>(data.AsEnumerable().ToArray());
-			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcUnit);
+			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcUnit));
 		}
 		catch (TcClientException ex)
 		{
-			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+			return ToolResults.Error($"{ex.Message} (HTTP {(int)ex.HttpStatus})");
 		}
 	}
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/UnitTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/UnitTools.cs
@@ -12,6 +12,7 @@ internal sealed class UnitTools
 	[McpServerTool(Name = "list_units"), Description("List rental units from TenantCloud. Can filter by property or occupancy status.")]
 	public static async Task<CallToolResult> ListUnits(
 		ITcClient client,
+		EntityCache cache,
 		[Description("Filter by property ID")] long? propertyId,
 		[Description("Filter by occupancy: occupied, vacant")] string? occupancy,
 		[Description("Maximum number of results to return (default 100)")] int? maxResults,
@@ -36,7 +37,9 @@ internal sealed class UnitTools
 
 			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
 			var result = new ListResult<TcUnit>(data.AsEnumerable().ToArray());
-			return ToolResults.Success(JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcUnit));
+			var json = JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcUnit);
+			json = await EntityEnricher.EnrichAsync(json, cache, ct).ConfigureAwait(false);
+			return ToolResults.Success(json);
 		}
 		catch (TcClientException ex)
 		{

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/UnitTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/UnitTools.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using Yllibed.TenantCloudClient.HttpMessages;
+
+namespace Yllibed.TenantCloudClient.Mcp.Tools;
+
+[McpServerToolType]
+internal sealed class UnitTools
+{
+	[McpServerTool(Name = "list_units"), Description("List rental units from TenantCloud. Can filter by property or occupancy status.")]
+	public static async Task<string> ListUnits(
+		ITcClient client,
+		[Description("Filter by property ID")] long? propertyId,
+		[Description("Filter by occupancy: occupied, vacant")] string? occupancy,
+		[Description("Maximum number of results to return (default 100)")] int? maxResults,
+		CancellationToken ct)
+	{
+		try
+		{
+			var source = client.Units;
+
+			if (propertyId.HasValue)
+			{
+				source = source.ForProperty(propertyId.Value);
+			}
+
+			source = occupancy?.ToLowerInvariant() switch
+			{
+				"occupied" => source.OnlyOccuped(),
+				"vacant" => source.OnlyVacant(),
+				null => source,
+				_ => source,
+			};
+
+			var data = await source.GetAll(ct, maxResults ?? 100).ConfigureAwait(false);
+			var result = new ListResult<TcUnit>(data.AsEnumerable().ToArray());
+			return JsonSerializer.Serialize(result, McpJsonContext.Default.ListResultTcUnit);
+		}
+		catch (TcClientException ex)
+		{
+			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/UserTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/UserTools.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+
+namespace Yllibed.TenantCloudClient.Mcp.Tools;
+
+[McpServerToolType]
+internal sealed class UserTools
+{
+	[McpServerTool(Name = "get_user_info"), Description("Get information about the currently signed-in TenantCloud user.")]
+	public static async Task<string> GetUserInfo(ITcClient client, CancellationToken ct)
+	{
+		try
+		{
+			var user = await client.GetUserInfo(ct).ConfigureAwait(false);
+
+			if (user is null)
+			{
+				return "No user info available. You may not be authenticated.";
+			}
+
+			return JsonSerializer.Serialize(user, McpJsonContext.Default.TcUserInfo);
+		}
+		catch (TcClientException ex)
+		{
+			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+		}
+	}
+}

--- a/src/Yllibed.TenantCloudClient.Mcp/Tools/UserTools.cs
+++ b/src/Yllibed.TenantCloudClient.Mcp/Tools/UserTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
 namespace Yllibed.TenantCloudClient.Mcp.Tools;
@@ -8,7 +9,7 @@ namespace Yllibed.TenantCloudClient.Mcp.Tools;
 internal sealed class UserTools
 {
 	[McpServerTool(Name = "get_user_info"), Description("Get information about the currently signed-in TenantCloud user.")]
-	public static async Task<string> GetUserInfo(ITcClient client, CancellationToken ct)
+	public static async Task<CallToolResult> GetUserInfo(ITcClient client, CancellationToken ct)
 	{
 		try
 		{
@@ -16,14 +17,14 @@ internal sealed class UserTools
 
 			if (user is null)
 			{
-				return "No user info available. You may not be authenticated.";
+				return ToolResults.Error("No user info available. You may not be authenticated.");
 			}
 
-			return JsonSerializer.Serialize(user, McpJsonContext.Default.TcUserInfo);
+			return ToolResults.Success(JsonSerializer.Serialize(user, McpJsonContext.Default.TcUserInfo));
 		}
 		catch (TcClientException ex)
 		{
-			return $"Error: {ex.Message} (HTTP {(int)ex.HttpStatus})";
+			return ToolResults.Error($"{ex.Message} (HTTP {(int)ex.HttpStatus})");
 		}
 	}
 }

--- a/src/Yllibed.TenantCloudClient.Mcp/Yllibed.TenantCloudClient.Mcp.csproj
+++ b/src/Yllibed.TenantCloudClient.Mcp/Yllibed.TenantCloudClient.Mcp.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net10.0</TargetFramework>
+		<AssemblyName>tc-mcp</AssemblyName>
+		<IsPackable>false</IsPackable>
+		<!-- XML docs will be added incrementally -->
+		<NoWarn>CS1591</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PublishReadyToRun>true</PublishReadyToRun>
+		<PublishSingleFile>true</PublishSingleFile>
+		<PublishTrimmed>true</PublishTrimmed>
+		<SelfContained>true</SelfContained>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Yllibed.TenantCloudClient\Yllibed.TenantCloudClient.csproj" />
+		<ProjectReference Include="..\Yllibed.TenantCloudClient.Cdp\Yllibed.TenantCloudClient.Cdp.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="ModelContextProtocol" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+	</ItemGroup>
+
+</Project>

--- a/src/Yllibed.TenantCloudClient.Tests/Given_JsonConverters.cs
+++ b/src/Yllibed.TenantCloudClient.Tests/Given_JsonConverters.cs
@@ -85,6 +85,18 @@ public class Given_JsonConverters
 	}
 
 	[TestMethod]
+	public void DateConverter_ReadsIsoDateString()
+	{
+		var json = """{"id": 1, "date": "2026-02-01", "amount": 0, "paid": 0, "balance": 0}""";
+		var result = JsonSerializer.Deserialize<TcTransaction>(json, Options);
+
+		result.Should().NotBeNull();
+		result!.DueDate.Month.Should().Be(2);
+		result.DueDate.Day.Should().Be(1);
+		result.DueDate.Year.Should().Be(2026);
+	}
+
+	[TestMethod]
 	public void NullableDateConverter_ReadsNull()
 	{
 		var json = """{"id": 1, "paid_at": null, "date": "1/1/2024", "amount": 0, "paid": 0, "balance": 0}""";

--- a/src/Yllibed.TenantCloudClient.Tests/TestBase.cs
+++ b/src/Yllibed.TenantCloudClient.Tests/TestBase.cs
@@ -1,24 +1,69 @@
+using Yllibed.TenantCloudClient.Cdp;
+
 namespace Yllibed.TenantCloudClient.Tests;
 
 public class TestBase
 {
-	private static readonly string? s_envToken =
-		Environment.GetEnvironmentVariable("TC_AUTH_TOKEN");
+	private static readonly bool IsCI =
+		!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
+		|| !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TF_BUILD"));
+
+	private static ITcAuthTokenProvider? s_cachedProvider;
+	private static bool s_providerResolved;
 
 	protected ITcAuthTokenProvider TokenProvider { get; private set; } = null!;
 
 	[TestInitialize]
-	public void EnsureTokenAvailable()
+	public async Task EnsureTokenAvailable()
 	{
-		var token = s_envToken;
+		if (!s_providerResolved)
+		{
+			s_cachedProvider = await ResolveProvider().ConfigureAwait(false);
+			s_providerResolved = true;
+		}
 
-		if (string.IsNullOrEmpty(token))
+		if (s_cachedProvider is null)
 		{
 			Assert.Inconclusive(
 				"No TenantCloud auth token available. " +
-				"Set TC_AUTH_TOKEN to run integration tests.");
+				"Set TC_AUTH_TOKEN or sign in via tc-mcp to run integration tests.");
 		}
 
-		TokenProvider = new StaticTokenProvider(token);
+		TokenProvider = s_cachedProvider;
+	}
+
+	private static async Task<ITcAuthTokenProvider?> ResolveProvider()
+	{
+		// 1. Environment variable (CI / manual override)
+		var envToken = Environment.GetEnvironmentVariable("TC_AUTH_TOKEN");
+		if (!string.IsNullOrEmpty(envToken))
+		{
+			return new StaticTokenProvider(envToken);
+		}
+
+		// 2. CdpTokenProvider: store → browser → interactive login (local only)
+		if (SecureTokenStore.IsSupported)
+		{
+			try
+			{
+				var provider = new CdpTokenProvider(new CdpTokenProviderOptions
+				{
+					TokenStore = new SecureTokenStore(),
+					AllowInteractiveLogin = !IsCI,
+				});
+
+				var token = await provider.GetToken(CancellationToken.None).ConfigureAwait(false);
+				if (!string.IsNullOrEmpty(token))
+				{
+					return provider;
+				}
+			}
+			catch
+			{
+				// Provider unavailable — fall through
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/Yllibed.TenantCloudClient.Tests/Yllibed.TenantCloudClient.Tests.csproj
+++ b/src/Yllibed.TenantCloudClient.Tests/Yllibed.TenantCloudClient.Tests.csproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Yllibed.TenantCloudClient\Yllibed.TenantCloudClient.csproj" />
+		<ProjectReference Include="..\Yllibed.TenantCloudClient.Cdp\Yllibed.TenantCloudClient.Cdp.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Yllibed.TenantCloudClient/HttpMessages/DateFormats.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/DateFormats.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+
+namespace Yllibed.TenantCloudClient.HttpMessages;
+
+internal static class DateFormats
+{
+	private static readonly string[] ExactFormats =
+	[
+		"yyyy-MM-dd",
+		"M/d/yyyy",
+		"MM/dd/yyyy",
+		"MM/d/yyyy",
+		"M/dd/yyyy",
+	];
+
+	public static bool TryParse(string? value, out DateTimeOffset result)
+	{
+		result = default;
+
+		if (value is null)
+		{
+			return false;
+		}
+
+		// Try exact date-only formats first
+		if (DateTimeOffset.TryParseExact(value, ExactFormats, DateTimeFormatInfo.InvariantInfo,
+			DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces, out result))
+		{
+			return true;
+		}
+
+		// Fallback: ISO 8601 with time (e.g. "2026-02-01T23:00:49.000000Z")
+		if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+			DateTimeStyles.RoundtripKind, out result))
+		{
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Yllibed.TenantCloudClient/HttpMessages/JsonStringDateToDateTimeOffsetConverter.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/JsonStringDateToDateTimeOffsetConverter.cs
@@ -4,18 +4,10 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public class JsonStringDateToDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
-	private static readonly string[] Formats =
-	[
-		"M/d/yyyy",
-		"MM/dd/yyyy",
-		"MM/d/yyyy",
-		"M/dd/yyyy",
-	];
-
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
 		var str = reader.GetString();
-		if (DateTimeOffset.TryParseExact(str, Formats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces, out var dto))
+		if (DateFormats.TryParse(str, out var dto))
 		{
 			return dto;
 		}

--- a/src/Yllibed.TenantCloudClient/HttpMessages/JsonStringDateToNullableDateTimeOffsetConverter.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/JsonStringDateToNullableDateTimeOffsetConverter.cs
@@ -4,14 +4,6 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public class JsonStringDateToNullableDateTimeOffsetConverter : JsonConverter<DateTimeOffset?>
 {
-	private static readonly string[] Formats =
-	[
-		"M/d/yyyy",
-		"MM/dd/yyyy",
-		"MM/d/yyyy",
-		"M/dd/yyyy",
-	];
-
 	public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
 		var str = reader.GetString();
@@ -20,7 +12,7 @@ public class JsonStringDateToNullableDateTimeOffsetConverter : JsonConverter<Dat
 			return null;
 		}
 
-		if (DateTimeOffset.TryParseExact(str, Formats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeLocal | DateTimeStyles.AllowWhiteSpaces, out var dto))
+		if (DateFormats.TryParse(str, out var dto))
 		{
 			return dto;
 		}

--- a/src/Yllibed.TenantCloudClient/HttpMessages/JsonTcLeaseStatusConverter.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/JsonTcLeaseStatusConverter.cs
@@ -1,0 +1,40 @@
+namespace Yllibed.TenantCloudClient.HttpMessages;
+
+public class JsonTcLeaseStatusConverter : JsonConverter<TcLeaseStatus>
+{
+	public override TcLeaseStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		switch (reader.TokenType)
+		{
+			case JsonTokenType.Number:
+				return (TcLeaseStatus)reader.GetByte();
+			case JsonTokenType.String:
+				var str = reader.GetString();
+				if (Enum.TryParse<TcLeaseStatus>(str, true, out var result))
+				{
+					return result;
+				}
+
+				throw new NotSupportedException($"Unknown lease status {str}");
+			default:
+				throw new NotSupportedException($"Type {reader.TokenType} not supported");
+		}
+	}
+
+	public override void Write(Utf8JsonWriter writer, TcLeaseStatus value, JsonSerializerOptions options)
+	{
+		writer.WriteStringValue(value switch
+		{
+			TcLeaseStatus.Active => "active",
+			TcLeaseStatus.Archived => "archived",
+			TcLeaseStatus.Ended => "ended",
+			TcLeaseStatus.Expired => "expired",
+			TcLeaseStatus.ExpiresIn => "expires_in",
+			TcLeaseStatus.Future => "future",
+			TcLeaseStatus.InsurancePending => "insurance_pending",
+			TcLeaseStatus.NotActive => "not_active",
+			TcLeaseStatus.Pending => "pending",
+			_ => value.ToString().ToLowerInvariant(),
+		});
+	}
+}

--- a/src/Yllibed.TenantCloudClient/HttpMessages/JsonTcTransactionStatusConverter.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/JsonTcTransactionStatusConverter.cs
@@ -23,6 +23,17 @@ public class JsonTcTransactionStatusConverter : JsonConverter<TcTransactionStatu
 
 	public override void Write(Utf8JsonWriter writer, TcTransactionStatus value, JsonSerializerOptions options)
 	{
-		writer.WriteNumberValue((byte)value);
+		writer.WriteStringValue(value switch
+		{
+			TcTransactionStatus.Due => "due",
+			TcTransactionStatus.Paid => "paid",
+			TcTransactionStatus.Partial => "partial",
+			TcTransactionStatus.Pending => "pending",
+			TcTransactionStatus.Void => "void",
+			TcTransactionStatus.WithBalance => "with_balance",
+			TcTransactionStatus.Overdue => "overdue",
+			TcTransactionStatus.Waive => "waive",
+			_ => value.ToString().ToLowerInvariant(),
+		});
 	}
 }

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcContact.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcContact.cs
@@ -4,7 +4,6 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public partial class TcContact : IHasId
 {
-	[JsonIgnore]
 	public long Id { get; set; }
 
 	[JsonPropertyName("email")]

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
@@ -16,6 +16,9 @@ public class TcLease : IHasId
 	[JsonPropertyName("rent_to")]
 	public DateTime? EndDate { get; set; }
 
+	[JsonPropertyName("move_out_date")]
+	public DateTime? MoveOutDate { get; set; }
+
 	[JsonPropertyName("unit_id")]
 	public long UnitId { get; set; }
 

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
@@ -20,6 +20,7 @@ public class TcLease : IHasId
 	public long UnitId { get; set; }
 
 	[JsonPropertyName("lease_status")]
+	[JsonConverter(typeof(JsonTcLeaseStatusConverter))]
 	public TcLeaseStatus Status { get; set; }
 
 	[JsonIgnore]

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
@@ -2,7 +2,6 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public class TcLease : IHasId
 {
-	[JsonIgnore]
 	public long Id { get; set; }
 
 	[JsonPropertyName("name")]

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcLease.cs
@@ -19,6 +19,10 @@ public class TcLease : IHasId
 	[JsonPropertyName("unit_id")]
 	public long UnitId { get; set; }
 
+	[JsonPropertyName("user_client_id")]
+	[JsonConverter(typeof(JsonAutoNullableLongConverter))]
+	public long? TenantId { get; set; }
+
 	[JsonPropertyName("lease_status")]
 	[JsonConverter(typeof(JsonTcLeaseStatusConverter))]
 	public TcLeaseStatus Status { get; set; }

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcProperty.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcProperty.cs
@@ -4,7 +4,6 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public class TcProperty : IHasId
 {
-	[JsonIgnore]
 	public long Id { get; set; }
 
 	[JsonPropertyName("name")]

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcTransaction.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcTransaction.cs
@@ -2,7 +2,6 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public class TcTransaction : IHasId
 {
-	[JsonIgnore]
 	public long Id { get; set; }
 
 	[JsonPropertyName("unit_id")]

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcTransaction.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcTransaction.cs
@@ -12,6 +12,10 @@ public class TcTransaction : IHasId
 	[JsonConverter(typeof(JsonAutoNullableLongConverter))]
 	public long? PropertyId { get; set; }
 
+	[JsonPropertyName("user_payer_id")]
+	[JsonConverter(typeof(JsonAutoNullableLongConverter))]
+	public long? PayerId { get; set; }
+
 	[JsonPropertyName("detail")]
 	public string? Detail { get; set; }
 

--- a/src/Yllibed.TenantCloudClient/HttpMessages/TcUnit.cs
+++ b/src/Yllibed.TenantCloudClient/HttpMessages/TcUnit.cs
@@ -2,7 +2,6 @@ namespace Yllibed.TenantCloudClient.HttpMessages;
 
 public class TcUnit : IHasId
 {
-	[JsonIgnore]
 	public long Id { get; set; }
 
 	[JsonPropertyName("property_id")]

--- a/src/Yllibed.TenantCloudClient/ITcTokenStore.cs
+++ b/src/Yllibed.TenantCloudClient/ITcTokenStore.cs
@@ -7,4 +7,5 @@ public interface ITcTokenStore
 {
 	Task<TcTokenSet?> LoadAsync(CancellationToken ct);
 	Task SaveAsync(TcTokenSet tokens, CancellationToken ct);
+	Task DeleteAsync(CancellationToken ct);
 }

--- a/src/Yllibed.TenantCloudClient/Internal/ISecureStorageBackend.cs
+++ b/src/Yllibed.TenantCloudClient/Internal/ISecureStorageBackend.cs
@@ -7,4 +7,5 @@ internal interface ISecureStorageBackend
 {
 	Task<byte[]?> LoadAsync(string serviceName, string accountKey, CancellationToken ct);
 	Task SaveAsync(string serviceName, string accountKey, byte[] data, CancellationToken ct);
+	Task DeleteAsync(string serviceName, string accountKey, CancellationToken ct);
 }

--- a/src/Yllibed.TenantCloudClient/Internal/LinuxSecretServiceBackend.cs
+++ b/src/Yllibed.TenantCloudClient/Internal/LinuxSecretServiceBackend.cs
@@ -41,4 +41,13 @@ internal sealed class LinuxSecretServiceBackend : ISecureStorageBackend
 				$"secret-tool store failed (exit code {exitCode}): {stderr.Trim()}");
 		}
 	}
+
+	public async Task DeleteAsync(string serviceName, string accountKey, CancellationToken ct)
+	{
+		await CliHelper.RunAsync(
+			"secret-tool",
+			$"clear service \"{serviceName}\" account \"{accountKey}\"",
+			stdinData: null,
+			ct).ConfigureAwait(false);
+	}
 }

--- a/src/Yllibed.TenantCloudClient/Internal/MacOsKeychainBackend.cs
+++ b/src/Yllibed.TenantCloudClient/Internal/MacOsKeychainBackend.cs
@@ -41,4 +41,13 @@ internal sealed class MacOsKeychainBackend : ISecureStorageBackend
 				$"security add-generic-password failed (exit code {exitCode}): {stderr.Trim()}");
 		}
 	}
+
+	public async Task DeleteAsync(string serviceName, string accountKey, CancellationToken ct)
+	{
+		await CliHelper.RunAsync(
+			"security",
+			$"delete-generic-password -s \"{serviceName}\" -a \"{accountKey}\"",
+			stdinData: null,
+			ct).ConfigureAwait(false);
+	}
 }

--- a/src/Yllibed.TenantCloudClient/Internal/WindowsDpapiBackend.cs
+++ b/src/Yllibed.TenantCloudClient/Internal/WindowsDpapiBackend.cs
@@ -110,6 +110,17 @@ internal sealed class WindowsDpapiBackend : ISecureStorageBackend
 		return Task.CompletedTask;
 	}
 
+	public Task DeleteAsync(string serviceName, string accountKey, CancellationToken ct)
+	{
+		var filePath = GetFilePath(accountKey);
+		if (File.Exists(filePath))
+		{
+			File.Delete(filePath);
+		}
+
+		return Task.CompletedTask;
+	}
+
 	private static string GetFilePath(string accountKey)
 	{
 		var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);

--- a/src/Yllibed.TenantCloudClient/SecureTokenStore.cs
+++ b/src/Yllibed.TenantCloudClient/SecureTokenStore.cs
@@ -73,6 +73,21 @@ public sealed class SecureTokenStore : ITcTokenStore
 		}
 	}
 
+	/// <inheritdoc />
+	public async Task DeleteAsync(CancellationToken ct)
+	{
+		await _gate.WaitAsync(ct).ConfigureAwait(false);
+		try
+		{
+			await _backend.DeleteAsync(
+				_options.ServiceName, _options.AccountKey, ct).ConfigureAwait(false);
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
 	private static ISecureStorageBackend CreateBackend()
 	{
 		if (OperatingSystem.IsWindows())

--- a/src/Yllibed.TenantCloudClient/TcTransactionsPaginatedSourceExtensions.cs
+++ b/src/Yllibed.TenantCloudClient/TcTransactionsPaginatedSourceExtensions.cs
@@ -66,23 +66,17 @@ public static class TcTransactionsPaginatedSourceExtensions
 
 	internal static string ToSerializedString(this TcTransactionStatus status)
 	{
-		switch (status)
+		return status switch
 		{
-			case TcTransactionStatus.Due:
-			case TcTransactionStatus.Paid:
-			case TcTransactionStatus.Partial:
-			case TcTransactionStatus.Pending:
-			case TcTransactionStatus.Void:
-				var b = (byte)status;
-				return b.ToString(NumberFormatInfo.InvariantInfo);
-			case TcTransactionStatus.WithBalance:
-				return "with_balance";
-			case TcTransactionStatus.Overdue:
-				return "overdue";
-			case TcTransactionStatus.Waive:
-				return "waive";
-			default:
-				throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown status");
-		}
+			TcTransactionStatus.Due => "due",
+			TcTransactionStatus.Paid => "paid",
+			TcTransactionStatus.Partial => "partial",
+			TcTransactionStatus.Pending => "pending",
+			TcTransactionStatus.Void => "void",
+			TcTransactionStatus.WithBalance => "with_balance",
+			TcTransactionStatus.Overdue => "overdue",
+			TcTransactionStatus.Waive => "waive",
+			_ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown status"),
+		};
 	}
 }

--- a/src/Yllibed.TenantCloudClient/Yllibed.TenantCloudClient.csproj
+++ b/src/Yllibed.TenantCloudClient/Yllibed.TenantCloudClient.csproj
@@ -35,7 +35,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="..\..\docs\nuget-client.md" Pack="true" PackagePath="\README.md" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

New project `Yllibed.TenantCloudClient.Mcp` — a standalone [Model Context Protocol](https://modelcontextprotocol.io) server (`tc-mcp`) that exposes TenantCloud data to AI agents (Claude Desktop, Claude Code, Cursor, etc.).

### MCP Tools

| Tool | Description | Filters |
|------|-------------|---------|
| `get_user_info` | Current signed-in user profile | — |
| `list_contacts` | Tenants, professionals, etc. | `role`, `maxResults` |
| `list_properties` | Rental properties | `maxResults` |
| `list_units` | Rental units | `propertyId`, `occupancy`, `maxResults` |
| `list_transactions` | Financial transactions | `tenantId`, `propertyId`, `unitId`, `status`, `category`, `maxResults` |
| `list_leases` | Lease agreements | `propertyId`, `unitId`, `status`, `maxResults` |

A `tc://guide` resource is also exposed to help the AI agent resolve human-readable names to IDs (e.g. "Evergreen Terrace" → propertyId) and understand available filters.

### Auto-configuration

```bash
tc-mcp install claude-desktop   # Patches the config JSON
tc-mcp install claude-code      # Runs claude mcp add
```

### Distribution

The CI pipeline publishes self-contained binaries for 6 platforms (win-x64, win-arm64, osx-x64, osx-arm64, linux-x64, linux-arm64) plus a portable .NET 10 build. All assets are attached to GitHub Releases.

### Documentation

The README is restructured as a hub linking to dedicated sub-documents: `docs/client-library.md`, `docs/mcp-server.md`, `docs/authentication.md`. NuGet packages get their own READMEs (`docs/nuget-client.md`, `docs/nuget-cdp.md`).

### Technical notes

- Source-generated JSON serialization (`McpJsonContext`) for AOT trimming compatibility
- The MCP SDK (`ModelContextProtocol` 0.8.0-preview.1) is in preview — API may change
- `CdpTokenProvider` is registered directly in DI (not via `AddCdpTokenProvider` extension) because `AllowInteractiveLogin` is an `init-only` property